### PR TITLE
UC-2 & UC-3 — Shared Datasets and Entry Factory

### DIFF
--- a/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
@@ -2,6 +2,7 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
 import {okGet} from '@tests/helpers/api-responses/UC-3-GetEntry';
+import {GetEntryDataset} from '@tests/helpers/datasets/Entries/GetEntryDataset';
 
 describe('AC01 — HttpGetEntryGateway returns entry on 200 JSON { data.item: {...} }', () => {
     let ctx: GatewayTestCtx;
@@ -15,21 +16,17 @@ describe('AC01 — HttpGetEntryGateway returns entry on 200 JSON { data.item: {.
     });
 
     it('returns entry when API responds with { success: true, data.item: {...} }', async () => {
-        const payload = okGet({
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-10-04T15:01:18+00:00',
-            updatedAt: '2025-10-04T15:01:18+00:00'
-        });
+        const item = GetEntryDataset.ac01HappyPath();
+        const payload = okGet(item);
 
         mockJsonOnce(ctx.fetchMock, 200, payload);
 
-        const entry = await ctx.gw.get(payload.data!.item.id);
+        const entry = await ctx.gw.get(item.id);
 
-        expect(entry.id).toBe('23d90e4f-e736-4260-8c31-ae9124fb9280');
-        expect(entry.title).toBe('Valid title');
-        expect(entry.body).toBe('Valid body');
+        expect(entry.id).toBe(item.id);
+        expect(entry.title).toBe(item.title);
+        expect(entry.body).toBe(item.body);
+
+        expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
+import {GetEntryDataset} from '@tests/helpers/datasets/Entries/GetEntryDataset';
 import {successFalseGet} from '@tests/helpers/api-responses/UC-3-GetEntry';
 
 describe('AC04 — HttpGetEntryGateway throws when success=false even on 200 OK', () => {
@@ -14,18 +15,12 @@ describe('AC04 — HttpGetEntryGateway throws when success=false even on 200 OK'
     });
 
     it('throws when API returns 200 OK but success=false', async () => {
-        const payload = successFalseGet({
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-10-04T15:01:18+00:00',
-            updatedAt: '2025-10-04T15:01:18+00:00'
-        });
+        const item = GetEntryDataset.ac04SuccessFalse();
+        const payload = successFalseGet(item);
 
         mockJsonOnce(ctx.fetchMock, 200, payload);
 
-        const fn = ctx.gw.get('23d90e4f-e736-4260-8c31-ae9124fb9280');
+        const fn = ctx.gw.get(item.id);
         const message = 'Malformed response for GET /api/entries/:id';
 
         await expect(fn).rejects.toThrow(message);

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
@@ -1,8 +1,9 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
 import {okList} from '@tests/helpers/api-responses/UC-2-ListEntries';
+import {ListEntriesDataset} from '@tests/helpers/datasets/Entries/ListEntriesDataset';
 
-describe('AC01 — HttpEntriesGateway returns list on 200 JSON { data.items: [...] }', () => {
+describe('AC01 — HttpListEntriesGateway returns items on 200 JSON { data.items: [...] }', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -13,18 +14,17 @@ describe('AC01 — HttpEntriesGateway returns list on 200 JSON { data.items: [..
         ctx.cleanup();
     });
 
-    it('returns entries when API responds with { success: true, data.items: [...] }', async () => {
-        const payload = okList([
-            {id: '1', title: 'First'},
-            {id: '2', title: 'Second'}
-        ]);
+    it('returns items with default sort by date DESC', async () => {
+        const items = ListEntriesDataset.ac01HappyPath();
+        const payload = okList(items);
 
         mockJsonOnce(ctx.fetchMock, 200, payload);
 
-        const entries = await ctx.gw.list();
+        // gw.list returns Entry[]
+        const list = await ctx.gw.list();
 
-        expect(entries.length).toBe(2);
-        expect(entries[0].title).toBe('First');
-        expect(entries[1].id).toBe('2');
+        expect(list.length).toBe(items.length);
+        expect(list[0].id).toBe(items[0].id);
+        expect(list[1].id).toBe(items[1].id);
     });
 });

--- a/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
@@ -1,4 +1,5 @@
 import type {Entry} from '@src/Domain/Entries/Entry';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
  * UC-3 datasets for frontend gateway tests.
@@ -19,14 +20,7 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac01HappyPath(): Entry {
-        const entry: Entry = {
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-10-04T15:01:18+00:00',
-            updatedAt: '2025-10-04T15:01:18+00:00'
-        };
+        const entry = EntryFactory.make({title: 'Valid title (AC-01)'});
 
         return entry;
     }
@@ -38,7 +32,8 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac04SuccessFalse(): Entry {
-        const entry = this.ac01HappyPath();
+        const entry = EntryFactory.make({title: 'Valid title (AC-04)'});
+
         return entry;
     }
 }

--- a/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
@@ -20,7 +20,7 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac01HappyPath(): Entry {
-        const entry = EntryFactory.make({title: 'Valid title (AC-01)'});
+        const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-01)'});
 
         return entry;
     }
@@ -32,7 +32,7 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac04SuccessFalse(): Entry {
-        const entry = EntryFactory.make({title: 'Valid title (AC-04)'});
+        const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-04)'});
 
         return entry;
     }

--- a/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
@@ -1,0 +1,44 @@
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * UC-3 datasets for frontend gateway tests.
+ *
+ * Purpose:
+ * Provide a single, shared source of truth for sample Entry objects
+ * used across acceptance-criteria tests (AC-01…AC-04).
+ *
+ * Mechanics:
+ * - Each method returns domain-shaped data that satisfies BR-2 timestamp
+ *   invariants and ENTRY-BR-4 (logical date).
+ */
+export class GetEntryDataset {
+    /**
+     * AC-01 — Happy Path.
+     * Returns a valid Entry object with stable, deterministic values.
+     *
+     * @returns {Entry} Valid entry.
+     */
+    static ac01HappyPath(): Entry {
+        const entry: Entry = {
+            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-12',
+            createdAt: '2025-10-04T15:01:18+00:00',
+            updatedAt: '2025-10-04T15:01:18+00:00'
+        };
+
+        return entry;
+    }
+
+    /**
+     * AC-04 — Success False
+     * Returns a valid entry for success=false scenario
+     *
+     * @returns {Entry} Valid entry.
+     */
+    static ac04SuccessFalse(): Entry {
+        const entry = this.ac01HappyPath();
+        return entry;
+    }
+}

--- a/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
@@ -21,14 +21,12 @@ export class ListEntriesDataset {
      */
     static ac01HappyPath(): Entry[] {
         const first = EntryFactory.make({
-            id: '591aef97-d0ae-4d86-b2cc-2a2ef6a71918',
-            title: 'Valid title (AC-01 #1)',
+            title: 'First entry',
             date: '2025-02-14'
         });
 
         const second = EntryFactory.make({
-            id: 'a68b6643-e713-4266-a7d5-8fad9d6f402a',
-            title: 'Valid title (AC-01 #2)',
+            title: 'Second entry',
             date: '2025-02-12'
         });
 

--- a/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
@@ -1,0 +1,44 @@
+// tests/helpers/datasets/ListEntriesDataset.ts
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * UC-2 datasets for frontend gateway tests.
+ *
+ * Purpose:
+ * Provide shared arrays of Entry objects for list scenarios, keeping
+ * AC-01…AC-04 tests consistent and DRY.
+ *
+ * Notes:
+ * - Default sort in UC-2 is "date DESC". The returned array follows
+ *   this order so tests can assert deterministic behavior.
+ */
+export class ListEntriesDataset {
+    /**
+     * AC-01 — Happy Path (default page, no filters).
+     * Returns entries sorted by date DESC.
+     *
+     * @returns {Entry[]} Array of valid entries.
+     */
+    static ac01HappyPath(): Entry[] {
+        const first: Entry = {
+            id: '591aef97-d0ae-4d86-b2cc-2a2ef6a71918',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-14',
+            createdAt: '2025-02-12T10:00:02+00:00',
+            updatedAt: '2025-02-12T10:00:02+00:00'
+        };
+
+        const second: Entry = {
+            id: 'a68b6643-e713-4266-a7d5-8fad9d6f402a',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-12',
+            createdAt: '2025-02-11T09:00:02+00:00',
+            updatedAt: '2025-02-11T09:00:02+00:00'
+        };
+
+        const items: Entry[] = [first, second];
+        return items;
+    }
+}

--- a/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
@@ -1,5 +1,5 @@
-// tests/helpers/datasets/ListEntriesDataset.ts
 import type {Entry} from '@src/Domain/Entries/Entry';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
  * UC-2 datasets for frontend gateway tests.
@@ -20,23 +20,17 @@ export class ListEntriesDataset {
      * @returns {Entry[]} Array of valid entries.
      */
     static ac01HappyPath(): Entry[] {
-        const first: Entry = {
+        const first = EntryFactory.make({
             id: '591aef97-d0ae-4d86-b2cc-2a2ef6a71918',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-14',
-            createdAt: '2025-02-12T10:00:02+00:00',
-            updatedAt: '2025-02-12T10:00:02+00:00'
-        };
+            title: 'Valid title (AC-01 #1)',
+            date: '2025-02-14'
+        });
 
-        const second: Entry = {
+        const second = EntryFactory.make({
             id: 'a68b6643-e713-4266-a7d5-8fad9d6f402a',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-02-11T09:00:02+00:00',
-            updatedAt: '2025-02-11T09:00:02+00:00'
-        };
+            title: 'Valid title (AC-01 #2)',
+            date: '2025-02-12'
+        });
 
         const items: Entry[] = [first, second];
         return items;

--- a/frontend/tests/helpers/factories/EntryFactory.ts
+++ b/frontend/tests/helpers/factories/EntryFactory.ts
@@ -1,5 +1,6 @@
 // tests/helpers/factories/EntryFactory.ts
 import type {Entry} from '@src/Domain/Entries/Entry';
+import {uuidv4} from '@tests/helpers/utils/uuid';
 
 /**
  * Factory for building deterministic Entry objects used in tests.
@@ -21,7 +22,7 @@ export class EntryFactory {
      */
     static make(overrides: Partial<Entry> = {}): Entry {
         const base: Entry = {
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
+            id: uuidv4(),
             title: 'Valid title',
             body: 'Valid body',
             date: '2025-02-12',

--- a/frontend/tests/helpers/factories/EntryFactory.ts
+++ b/frontend/tests/helpers/factories/EntryFactory.ts
@@ -1,0 +1,35 @@
+// tests/helpers/factories/EntryFactory.ts
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * Factory for building deterministic Entry objects used in tests.
+ *
+ * Purpose:
+ * Provide a single, reusable generator for Entry domain models
+ * across all datasets (GetEntry, ListEntries, UpdateEntry, etc.).
+ *
+ * Mechanics:
+ * - Produces a valid baseline Entry that satisfies domain rules.
+ * - Accepts partial overrides to change specific fields.
+ */
+export class EntryFactory {
+    /**
+     * Builds a valid Entry object with optional overrides.
+     *
+     * @param {Partial<Entry>} overrides Optional field overrides.
+     * @returns {Entry} Valid Entry object.
+     */
+    static make(overrides: Partial<Entry> = {}): Entry {
+        const base: Entry = {
+            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-12',
+            createdAt: '2025-10-04T15:01:18+00:00',
+            updatedAt: '2025-10-04T15:01:18+00:00'
+        };
+
+        const entry: Entry = {...base, ...overrides};
+        return entry;
+    }
+}

--- a/frontend/tests/helpers/utils/uuid.ts
+++ b/frontend/tests/helpers/utils/uuid.ts
@@ -1,0 +1,16 @@
+/**
+ * Simple UUID v4 generator for test data.
+ *
+ * Purpose:
+ * Produce pseudo-random UUIDs using only built-in JS functions.
+ * Not cryptographically secure, but sufficient for test fixtures.
+ *
+ * @returns {string} UUID v4 string, e.g. "3f6f38d2-9a2a-4c9b-b821-7a5a1b93a3d4".
+ */
+export function uuidv4(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+}

--- a/frontend/tests/helpers/utils/uuid.ts
+++ b/frontend/tests/helpers/utils/uuid.ts
@@ -8,7 +8,7 @@
  * @returns {string} UUID v4 string, e.g. "3f6f38d2-9a2a-4c9b-b821-7a5a1b93a3d4".
  */
 export function uuidv4(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
         const r = (Math.random() * 16) | 0;
         const v = c === 'x' ? r : (r & 0x3) | 0x8;
         return v.toString(16);


### PR DESCRIPTION
Refactors frontend gateway tests to eliminate duplicated inline payloads and introduce shared, reusable helpers for test data generation.

Adds centralized EntryFactory, uuid utility, and per-use-case datasets to provide a single source of truth for sample entries.

All acceptance criteria (AC-01…AC-04) for both ListEntries and GetEntry gateways are updated accordingly.

Resolves #15