### PR TITLE
UC-1 — Add Entry with discriminated UseCaseResponse;

### DIFF
--- a/frontend/src/Application/DTO/Common/UseCaseResponse.ts
+++ b/frontend/src/Application/DTO/Common/UseCaseResponse.ts
@@ -8,9 +8,6 @@
  *
  * @template T Data payload shape for a specific use-case.
  */
-export interface UseCaseResponse<T> {
-    success: boolean;
-    data?: T;
-    status?: number;
-    code?: string;
-}
+export type UseCaseResponse<T> =
+    | {success: true; status: number; data: T}
+    | {success: false; status: number; code?: string};

--- a/frontend/src/Application/DTO/Entries/AddEntry/AddEntryRequest.ts
+++ b/frontend/src/Application/DTO/Entries/AddEntry/AddEntryRequest.ts
@@ -1,0 +1,11 @@
+/**
+ * UC-1: Add Entry — request DTO.
+ *
+ * Represents the transport-level payload required to create a new entry.
+ * Higher layers validate lengths and calendar date rules.
+ */
+export type AddEntryRequest = {
+    title: string;
+    body: string;
+    date: string; // strict YYYY-MM-DD
+};

--- a/frontend/src/Application/DTO/Entries/AddEntry/AddEntryResponse.ts
+++ b/frontend/src/Application/DTO/Entries/AddEntry/AddEntryResponse.ts
@@ -3,12 +3,6 @@ import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse'
 
 /**
  * UC-1: Add Entry — response DTO.
- *
- * Mirrors the backend payload:
- * {
- *   success: true,
- *   data: Entry,
- *   status: 200
- * }
+ * Mirrors backend: { success:true, status:200, data: Entry }.
  */
-export interface AddEntryResponse extends UseCaseResponse<Entry> {}
+export type AddEntryResponse = UseCaseResponse<Entry>;

--- a/frontend/src/Application/DTO/Entries/AddEntry/AddEntryResponse.ts
+++ b/frontend/src/Application/DTO/Entries/AddEntry/AddEntryResponse.ts
@@ -1,0 +1,14 @@
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+
+/**
+ * UC-1: Add Entry — response DTO.
+ *
+ * Mirrors the backend payload:
+ * {
+ *   success: true,
+ *   data: Entry,
+ *   status: 200
+ * }
+ */
+export interface AddEntryResponse extends UseCaseResponse<Entry> {}

--- a/frontend/src/Application/DTO/Entries/ListEntries/ListEntriesResponse.ts
+++ b/frontend/src/Application/DTO/Entries/ListEntries/ListEntriesResponse.ts
@@ -1,5 +1,5 @@
-import type {Entry} from '../../../../Domain/Entries/Entry';
-import type {UseCaseResponse} from '../../Common/UseCaseResponse';
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 
 export interface ListEntriesData {
     items: Entry[];

--- a/frontend/src/Infrastructure/Entries/AddEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/AddEntryGateway.ts
@@ -1,0 +1,46 @@
+import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+
+/**
+ * UC-1: Add Entry (Frontend)
+ *
+ * Sends a new journal entry to POST /api/entries.
+ *
+ * Performs minimal transport-level validation:
+ * - res.ok must be true;
+ * - success must be true;
+ * - data.item must be a non-null object.
+ *
+ * Does not validate Entry fields — handled on the backend and in higher layers.
+ */
+export class AddEntryGateway {
+    private readonly http: HttpClient;
+
+    constructor(http: HttpClient) {
+        this.http = http;
+    }
+
+    /**
+     * Sends entry payload to POST /api/entries and returns created Entry.
+     *
+     * @param {{title:string; body:string; date:string}} req Valid AddEntry request payload.
+     * @returns {Promise<Entry>} Created entry returned by the server.
+     * @throws {Error} If transport or response structure is invalid.
+     */
+    async add(req: {title: string; body: string; date: string}): Promise<Entry> {
+        const url = '/api/entries';
+        const json = await this.http.request<UseCaseResponse<{item: Entry}>>('POST', url, req);
+
+        const ok = json?.success === true;
+        const hasItem = typeof json?.data?.item === 'object' && json.data.item !== null;
+
+        if (!ok || !hasItem) {
+            const message = 'Malformed response for POST /api/entries';
+            throw new Error(message);
+        }
+
+        const entry = json.data!.item;
+        return entry;
+    }
+}

--- a/frontend/src/Infrastructure/Entries/AddEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/AddEntryGateway.ts
@@ -39,15 +39,19 @@ export class AddEntryGateway {
         const url = '/api/entries';
         const json = await this.http.request<UseCaseResponse<Entry>>('POST', url, req);
 
-        const ok = json?.success === true;
-        const hasData = typeof json?.data === 'object' && json.data !== null;
-        console.log('hasData', hasData);
-        if (!ok || !hasData) {
+        if (json.success !== true) {
+            const message = 'Malformed response for POST /api/entries';
+            throw new Error(message);
+        }
+
+        const hasData = typeof json.data === 'object' && json.data !== null;
+        if (!hasData) {
             const message = 'Malformed response for POST /api/entries';
             throw new Error(message);
         }
 
         const entry = json.data as Entry;
+
         return entry;
     }
 }

--- a/frontend/src/Infrastructure/Entries/AddEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/AddEntryGateway.ts
@@ -1,6 +1,7 @@
 import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
 import type {Entry} from '@src/Domain/Entries/Entry';
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {AddEntryRequest} from '@src/Application/DTO/Entries/AddEntry/AddEntryRequest';
 
 /**
  * UC-1: Add Entry (Frontend)
@@ -22,25 +23,31 @@ export class AddEntryGateway {
     }
 
     /**
-     * Sends entry payload to POST /api/entries and returns created Entry.
+     * UC-1: Add Entry (Frontend, Gateway)
      *
-     * @param {{title:string; body:string; date:string}} req Valid AddEntry request payload.
+     * Sends AddEntry payload to POST /api/entries and returns the created Entry.
+     *
+     * Transport-level validation only:
+     * - success must be true;
+     * - data must be a non-null object (backend returns Entry directly in data).
+     *
+     * @param {AddEntryRequest} req Valid AddEntry request payload.
      * @returns {Promise<Entry>} Created entry returned by the server.
-     * @throws {Error} If transport or response structure is invalid.
+     * @throws {Error} If HTTP status is non-2xx or response structure is invalid.
      */
-    async add(req: {title: string; body: string; date: string}): Promise<Entry> {
+    async add(req: AddEntryRequest): Promise<Entry> {
         const url = '/api/entries';
-        const json = await this.http.request<UseCaseResponse<{item: Entry}>>('POST', url, req);
+        const json = await this.http.request<UseCaseResponse<Entry>>('POST', url, req);
 
         const ok = json?.success === true;
-        const hasItem = typeof json?.data?.item === 'object' && json.data.item !== null;
-
-        if (!ok || !hasItem) {
+        const hasData = typeof json?.data === 'object' && json.data !== null;
+        console.log('hasData', hasData);
+        if (!ok || !hasData) {
             const message = 'Malformed response for POST /api/entries';
             throw new Error(message);
         }
 
-        const entry = json.data!.item;
+        const entry = json.data as Entry;
         return entry;
     }
 }

--- a/frontend/src/Infrastructure/Http/FetchHttpClient.ts
+++ b/frontend/src/Infrastructure/Http/FetchHttpClient.ts
@@ -10,8 +10,8 @@ export class FetchHttpClient implements HttpClient {
 
     async request<T>(method: HttpMethod, url: string, init: RequestInit = {}): Promise<T> {
         // prettier-ignore
-        const fullUrl = url.startsWith('http') 
-            ? url 
+        const fullUrl = url.startsWith('http')
+            ? url
             : `${this.baseUrl}${url}`;
 
         const res = await fetch(fullUrl, {
@@ -22,7 +22,7 @@ export class FetchHttpClient implements HttpClient {
             },
             body: init.body
         });
-
+        console.log(fullUrl);
         if (!res.ok) {
             const message = `HTTP ${res.status} for ${fullUrl}`;
             throw new Error(message);
@@ -31,8 +31,8 @@ export class FetchHttpClient implements HttpClient {
         const text = await res.text();
 
         // prettier-ignore
-        const data = text 
-            ? JSON.parse(text) 
+        const data = text
+            ? JSON.parse(text)
             : undefined;
 
         return data as T;

--- a/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
@@ -36,12 +36,19 @@ describe('AC01 — AddEntryGateway returns entry (mocked)', () => {
         const request  = makeRequest();
         const response = makeResponse(request);
 
+        // Ensure test factory returned the success-branch payload.
+        // This guard narrows the union type AddEntryResponse so that
+        // TypeScript recognizes `data` as defined in the success case.
+        if (response.success !== true) {
+            throw new Error('Test setup error: expected success response');
+        }
+
         mockJsonOnce(ctx.fetchMock, 200, response);
         const entry = await ctx.gw.add(request);
 
-        expect(entry.title).toBe(response.data!.title);
-        expect(entry.body).toBe(response.data!.body);
-        expect(entry.date).toBe(response.data!.date);
+        expect(entry.title).toBe(response.data.title);
+        expect(entry.body).toBe(response.data.body);
+        expect(entry.date).toBe(response.data.date);
         expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
@@ -1,10 +1,25 @@
+// frontend/tests/Unit/Entries/AddEntry/Http/AC01_HappyPath.test.ts
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
-import {okPost} from '@tests/helpers/api-responses/UC-1-AddEntry';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
+import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/AddEntryResponseFactory';
 
-//import {AddEntryRequestDataset} from '@tests/helpers/datasets/Entries/AddEntryRequestDataset';
-import {AddEntryDataset} from '@tests/helpers/datasets/Entries/AddEntryDataset';
-
+/**
+ * UC-1: Add Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that HttpAddEntryGateway resolves with Entry when API responds
+ * 200 + { success: true, data.item }.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals in the call site).
+ * - Build a matching response via response factory from the same request.
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert the gateway returns Entry consistent with response.item.
+ *
+ * Cases covered:
+ * - AC-01 — Happy path with well-formed JSON and success=true.
+ */
 describe('AC01 — AddEntryGateway returns entry (mocked)', () => {
     let ctx: GatewayTestCtx;
 
@@ -17,15 +32,16 @@ describe('AC01 — AddEntryGateway returns entry (mocked)', () => {
     });
 
     it('returns entry when called with valid payload', async () => {
-        const item = AddEntryDataset.ac01HappyPath();
-        const payload = okPost(item);
+        //prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request);
 
-        mockJsonOnce(ctx.fetchMock, 200, payload);
-        const entry = await ctx.gw.add(item);
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const entry = await ctx.gw.add(request);
 
-        expect(entry.title).toBe(item.title);
-        expect(entry.body).toBe(item.body);
-        expect(entry.date).toBe(item.date);
+        expect(entry.title).toBe(response.data!.title);
+        expect(entry.body).toBe(response.data!.body);
+        expect(entry.date).toBe(response.data!.date);
         expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
+import {okPost} from '@tests/helpers/api-responses/UC-1-AddEntry';
+
+//import {AddEntryRequestDataset} from '@tests/helpers/datasets/Entries/AddEntryRequestDataset';
+import {AddEntryDataset} from '@tests/helpers/datasets/Entries/AddEntryDataset';
+
+describe('AC01 — AddEntryGateway returns entry (mocked)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('returns entry when called with valid payload', async () => {
+        const item = AddEntryDataset.ac01HappyPath();
+        const payload = okPost(item);
+
+        mockJsonOnce(ctx.fetchMock, 200, payload);
+        const entry = await ctx.gw.add(item);
+
+        expect(entry.title).toBe(item.title);
+        expect(entry.body).toBe(item.body);
+        expect(entry.date).toBe(item.date);
+        expect(entry.createdAt <= entry.updatedAt).toBe(true);
+    });
+});

--- a/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
@@ -1,7 +1,7 @@
 // frontend/tests/Unit/Entries/AddEntry/Http/AC02_Non2xxResponse.test.ts
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
-import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
+import {ac02Non2xxResponse as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
 import {
     makeBadRequest,
     makeInternalError
@@ -35,9 +35,9 @@ describe('AC02 — AddEntryGateway throws on non-2xx response (generic)', () => 
 
     it('throws when API responds with 400 Bad Request', async () => {
         // Arrange
-        const request  = makeRequest();
+        const request = makeRequest();
         const response = makeBadRequest();
-        const status   = 400;
+        const status = 400;
 
         mockJsonOnce(ctx.fetchMock, status, response);
 
@@ -52,9 +52,9 @@ describe('AC02 — AddEntryGateway throws on non-2xx response (generic)', () => 
 
     it('throws when API responds with 500 Internal Server Error', async () => {
         // Arrange
-        const request  = makeRequest();
+        const request = makeRequest();
         const response = makeInternalError();
-        const status   = 500;
+        const status = 500;
 
         mockJsonOnce(ctx.fetchMock, status, response);
 

--- a/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
@@ -35,35 +35,33 @@ describe('AC02 — AddEntryGateway throws on non-2xx response (generic)', () => 
 
     it('throws when API responds with 400 Bad Request', async () => {
         // Arrange
-        const request = makeRequest();
+        // prettier-ignore
+        const request  = makeRequest();
         const response = makeBadRequest();
-        const status = 400;
 
-        mockJsonOnce(ctx.fetchMock, status, response);
+        mockJsonOnce(ctx.fetchMock, 400, response);
 
         // Act
-        const call = async () => {
-            await ctx.gw.add(request);
-        };
+        const fn = ctx.gw.add(request);
+        const message = /400|bad request/i;
 
         // Assert
-        await expect(call).rejects.toThrowError(/400|bad request/i);
+        await expect(fn).rejects.toThrowError(message);
     });
 
     it('throws when API responds with 500 Internal Server Error', async () => {
         // Arrange
-        const request = makeRequest();
+        // prettier-ignore
+        const request  = makeRequest();
         const response = makeInternalError();
-        const status = 500;
 
-        mockJsonOnce(ctx.fetchMock, status, response);
+        mockJsonOnce(ctx.fetchMock, 500, response);
 
         // Act
-        const call = async () => {
-            await ctx.gw.add(request);
-        };
+        const fn = ctx.gw.add(request);
+        const message = /500|internal/i;
 
         // Assert
-        await expect(call).rejects.toThrowError(/500|internal/i);
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
@@ -1,0 +1,69 @@
+// frontend/tests/Unit/Entries/AddEntry/Http/AC02_Non2xxResponse.test.ts
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
+import {
+    makeBadRequest,
+    makeInternalError
+} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
+
+/**
+ * UC-1: Add Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that HttpAddEntryGateway rejects on generic non-2xx HTTP responses.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Use common non-2xx response factories (no domain codes asserted here).
+ * - Mock fetch with 400/500 and assert rejection.
+ *
+ * Cases:
+ * - AC-02a — 400 Bad Request → rejects.
+ * - AC-02b — 500 Internal Server Error → rejects.
+ */
+describe('AC02 — AddEntryGateway throws on non-2xx response (generic)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when API responds with 400 Bad Request', async () => {
+        // Arrange
+        const request  = makeRequest();
+        const response = makeBadRequest();
+        const status   = 400;
+
+        mockJsonOnce(ctx.fetchMock, status, response);
+
+        // Act
+        const call = async () => {
+            await ctx.gw.add(request);
+        };
+
+        // Assert
+        await expect(call).rejects.toThrowError(/400|bad request/i);
+    });
+
+    it('throws when API responds with 500 Internal Server Error', async () => {
+        // Arrange
+        const request  = makeRequest();
+        const response = makeInternalError();
+        const status   = 500;
+
+        mockJsonOnce(ctx.fetchMock, status, response);
+
+        // Act
+        const call = async () => {
+            await ctx.gw.add(request);
+        };
+
+        // Assert
+        await expect(call).rejects.toThrowError(/500|internal/i);
+    });
+});

--- a/frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts
@@ -1,7 +1,7 @@
 // frontend/tests/Unit/Entries/AddEntry/Http/AC03_MalformedJson.test.ts
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
-import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
+import {ac03MalformedJson as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
 import {ac03MalformedJson as makeResponse} from '@tests/helpers/http/responses/entries/AddEntryResponseFactory';
 
 /**
@@ -31,9 +31,10 @@ describe('AC03 — AddEntryGateway throws on malformed JSON', () => {
 
     it('throws when API responds with malformed JSON', async () => {
         // Arrange
-        const request = makeRequest();
+        // prettier-ignore
+        const request  = makeRequest();
         const response = makeResponse(request);
-        console.log(request, response);
+
         mockJsonOnce(ctx.fetchMock, 200, response);
 
         // Act

--- a/frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts
@@ -1,0 +1,46 @@
+// frontend/tests/Unit/Entries/AddEntry/Http/AC03_MalformedJson.test.ts
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
+import {ac03MalformedJson as makeResponse} from '@tests/helpers/http/responses/entries/AddEntryResponseFactory';
+
+/**
+ * UC-1: Add Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that HttpAddEntryGateway rejects when API responds with malformed JSON payload.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Mock fetch to return plain text that cannot be parsed as JSON.
+ * - Expect the gateway to reject with an error mentioning invalid/malformed JSON.
+ *
+ * Cases covered:
+ * - AC-03 — Malformed JSON response causes rejection.
+ */
+describe('AC03 — AddEntryGateway throws on malformed JSON', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when API responds with malformed JSON', async () => {
+        // Arrange
+        const request = makeRequest();
+        const response = makeResponse(request);
+        console.log(request, response);
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        // Act
+        const fn = ctx.gw.add(request);
+
+        // Assert
+        const message = 'Malformed response for POST /api/entries';
+        await expect(fn).rejects.toThrow(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/AddEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC04_SuccessFalse.test.ts
@@ -1,0 +1,47 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
+import {ac04SuccessFalse as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
+import {ac04SuccessFalse as makeResponse} from '@tests/helpers/http/responses/entries/AddEntryResponseFactory';
+
+/**
+ * UC-1: Add Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that HttpAddEntryGateway rejects when API responds with success=false,
+ * even if HTTP status is 200.
+ *
+ * Mechanics:
+ * - Build a valid request via factory.
+ * - Mock fetch with JSON { success:false, status:200, code:"ANY_CODE" }.
+ * - Expect the gateway to throw transport-level error.
+ *
+ * Cases covered:
+ * - AC-04 — success=false + 200 → rejects.
+ */
+describe('AC04 — AddEntryGateway throws when success=false (even with 200)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when API returns success=false', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request);
+
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        // Act
+        const fn = ctx.gw.add(request);
+        const message = 'Malformed response for POST /api/entries';
+
+        // Assert
+        await expect(fn).rejects.toThrow(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/AddEntry/BaseAddEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/BaseAddEntryGatewayTest.ts
@@ -1,0 +1,24 @@
+import {type HttpTestCtxBase, createHttpCtx} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+import {AddEntryGateway} from '@src/Infrastructure/Entries/AddEntryGateway';
+
+export type GatewayTestCtx = HttpTestCtxBase & {
+    gw: AddEntryGateway;
+};
+
+/**
+ * Provides a mocked AddEntryGateway built over shared HTTP test context.
+ * The caller is responsible for calling ctx.cleanup() in afterEach().
+ */
+export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
+    const base = createHttpCtx(baseUrl);
+    const gw = new AddEntryGateway(base.http);
+
+    const ctx: GatewayTestCtx = {
+        ...base,
+        gw
+    };
+
+    return ctx;
+}
+
+export {mockJsonOnce} from '@tests/Unit/Entries/BaseEntriesGatewayTest';

--- a/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
@@ -2,6 +2,7 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
 import {okGet} from '@tests/helpers/api-responses/UC-3-GetEntry';
+import {GetEntryDataset} from '@tests/helpers/datasets/Entries/GetEntryDataset';
 
 describe('AC01 — HttpGetEntryGateway returns entry on 200 JSON { data.item: {...} }', () => {
     let ctx: GatewayTestCtx;
@@ -15,21 +16,17 @@ describe('AC01 — HttpGetEntryGateway returns entry on 200 JSON { data.item: {.
     });
 
     it('returns entry when API responds with { success: true, data.item: {...} }', async () => {
-        const payload = okGet({
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-10-04T15:01:18+00:00',
-            updatedAt: '2025-10-04T15:01:18+00:00'
-        });
+        const item = GetEntryDataset.ac01HappyPath();
+        const payload = okGet(item);
 
         mockJsonOnce(ctx.fetchMock, 200, payload);
 
-        const entry = await ctx.gw.get(payload.data!.item.id);
+        const entry = await ctx.gw.get(item.id);
 
-        expect(entry.id).toBe('23d90e4f-e736-4260-8c31-ae9124fb9280');
-        expect(entry.title).toBe('Valid title');
-        expect(entry.body).toBe('Valid body');
+        expect(entry.id).toBe(item.id);
+        expect(entry.title).toBe(item.title);
+        expect(entry.body).toBe(item.body);
+
+        expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
+import {GetEntryDataset} from '@tests/helpers/datasets/Entries/GetEntryDataset';
 import {successFalseGet} from '@tests/helpers/api-responses/UC-3-GetEntry';
 
 describe('AC04 — HttpGetEntryGateway throws when success=false even on 200 OK', () => {
@@ -14,18 +15,12 @@ describe('AC04 — HttpGetEntryGateway throws when success=false even on 200 OK'
     });
 
     it('throws when API returns 200 OK but success=false', async () => {
-        const payload = successFalseGet({
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-10-04T15:01:18+00:00',
-            updatedAt: '2025-10-04T15:01:18+00:00'
-        });
+        const item = GetEntryDataset.ac04SuccessFalse();
+        const payload = successFalseGet(item);
 
         mockJsonOnce(ctx.fetchMock, 200, payload);
 
-        const fn = ctx.gw.get('23d90e4f-e736-4260-8c31-ae9124fb9280');
+        const fn = ctx.gw.get(item.id);
         const message = 'Malformed response for GET /api/entries/:id';
 
         await expect(fn).rejects.toThrow(message);

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
@@ -1,8 +1,9 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
 import {okList} from '@tests/helpers/api-responses/UC-2-ListEntries';
+import {ListEntriesDataset} from '@tests/helpers/datasets/Entries/ListEntriesDataset';
 
-describe('AC01 — HttpEntriesGateway returns list on 200 JSON { data.items: [...] }', () => {
+describe('AC01 — HttpListEntriesGateway returns items on 200 JSON { data.items: [...] }', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -13,18 +14,17 @@ describe('AC01 — HttpEntriesGateway returns list on 200 JSON { data.items: [..
         ctx.cleanup();
     });
 
-    it('returns entries when API responds with { success: true, data.items: [...] }', async () => {
-        const payload = okList([
-            {id: '1', title: 'First'},
-            {id: '2', title: 'Second'}
-        ]);
+    it('returns items with default sort by date DESC', async () => {
+        const items = ListEntriesDataset.ac01HappyPath();
+        const payload = okList(items);
 
         mockJsonOnce(ctx.fetchMock, 200, payload);
 
-        const entries = await ctx.gw.list();
+        // gw.list returns Entry[]
+        const list = await ctx.gw.list();
 
-        expect(entries.length).toBe(2);
-        expect(entries[0].title).toBe('First');
-        expect(entries[1].id).toBe('2');
+        expect(list.length).toBe(items.length);
+        expect(list[0].id).toBe(items[0].id);
+        expect(list[1].id).toBe(items[1].id);
     });
 });

--- a/frontend/tests/helpers/api-responses/UC-1-AddEntry.ts
+++ b/frontend/tests/helpers/api-responses/UC-1-AddEntry.ts
@@ -1,0 +1,49 @@
+// Test response factories for UC-1 Add Entry.
+// Purpose: build consistent API payloads for gateway unit tests.
+
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+
+/**
+ * Successful UseCaseResponse<{item: Entry}>.
+ *
+ * Used in AC-01 (Happy Path) where:
+ *  - HTTP status = 200;
+ *  - success = true;
+ *  - data.item contains the created entry.
+ */
+export function okPost(item: Entry): UseCaseResponse<{item: Entry}> {
+    const response: UseCaseResponse<{item: Entry}> = {
+        success: true,
+        data: {item},
+        status: 200
+    };
+
+    return response;
+}
+
+/**
+ * 200 OK but malformed shape (no data.item object).
+ */
+export function okMalformedPostWithoutItem(): UseCaseResponse<unknown> {
+    const response: UseCaseResponse<unknown> = {
+        success: true,
+        data: {} as unknown,
+        status: 200
+    };
+
+    return response;
+}
+
+/**
+ * 200 OK but success=false (logical failure on server side).
+ */
+export function successFalsePost(item: Entry): UseCaseResponse<{item: Entry}> {
+    const response: UseCaseResponse<{item: Entry}> = {
+        success: false,
+        data: {item},
+        status: 200
+    };
+
+    return response;
+}

--- a/frontend/tests/helpers/datasets/Entries/AddEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/AddEntryDataset.ts
@@ -1,0 +1,26 @@
+import type {Entry} from '@src/Domain/Entries/Entry';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+
+/**
+ * UC-1 (Add Entry) — response item datasets.
+ *
+ * Purpose:
+ * Provide deterministic Entry objects (what backend returns in data.item).
+ */
+export class AddEntryDataset {
+    /**
+     * AC-01 — Happy Path item.
+     */
+    static ac01HappyPath(): Entry {
+        const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-01)'});
+        return entry;
+    }
+
+    /**
+     * AC-04 — Success=false.
+     */
+    static ac04SuccessFalse(): Entry {
+        const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-04)'});
+        return entry;
+    }
+}

--- a/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
@@ -1,4 +1,5 @@
 import type {Entry} from '@src/Domain/Entries/Entry';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
  * UC-3 datasets for frontend gateway tests.
@@ -19,14 +20,7 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac01HappyPath(): Entry {
-        const entry: Entry = {
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-10-04T15:01:18+00:00',
-            updatedAt: '2025-10-04T15:01:18+00:00'
-        };
+        const entry = EntryFactory.make({title: 'Valid title (AC-01)'});
 
         return entry;
     }
@@ -38,7 +32,8 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac04SuccessFalse(): Entry {
-        const entry = this.ac01HappyPath();
+        const entry = EntryFactory.make({title: 'Valid title (AC-04)'});
+
         return entry;
     }
 }

--- a/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
@@ -20,7 +20,7 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac01HappyPath(): Entry {
-        const entry = EntryFactory.make({title: 'Valid title (AC-01)'});
+        const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-01)'});
 
         return entry;
     }
@@ -32,7 +32,7 @@ export class GetEntryDataset {
      * @returns {Entry} Valid entry.
      */
     static ac04SuccessFalse(): Entry {
-        const entry = EntryFactory.make({title: 'Valid title (AC-04)'});
+        const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-04)'});
 
         return entry;
     }

--- a/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/GetEntryDataset.ts
@@ -1,0 +1,44 @@
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * UC-3 datasets for frontend gateway tests.
+ *
+ * Purpose:
+ * Provide a single, shared source of truth for sample Entry objects
+ * used across acceptance-criteria tests (AC-01…AC-04).
+ *
+ * Mechanics:
+ * - Each method returns domain-shaped data that satisfies BR-2 timestamp
+ *   invariants and ENTRY-BR-4 (logical date).
+ */
+export class GetEntryDataset {
+    /**
+     * AC-01 — Happy Path.
+     * Returns a valid Entry object with stable, deterministic values.
+     *
+     * @returns {Entry} Valid entry.
+     */
+    static ac01HappyPath(): Entry {
+        const entry: Entry = {
+            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-12',
+            createdAt: '2025-10-04T15:01:18+00:00',
+            updatedAt: '2025-10-04T15:01:18+00:00'
+        };
+
+        return entry;
+    }
+
+    /**
+     * AC-04 — Success False
+     * Returns a valid entry for success=false scenario
+     *
+     * @returns {Entry} Valid entry.
+     */
+    static ac04SuccessFalse(): Entry {
+        const entry = this.ac01HappyPath();
+        return entry;
+    }
+}

--- a/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
@@ -21,14 +21,12 @@ export class ListEntriesDataset {
      */
     static ac01HappyPath(): Entry[] {
         const first = EntryFactory.make({
-            id: '591aef97-d0ae-4d86-b2cc-2a2ef6a71918',
-            title: 'Valid title (AC-01 #1)',
+            title: 'First entry',
             date: '2025-02-14'
         });
 
         const second = EntryFactory.make({
-            id: 'a68b6643-e713-4266-a7d5-8fad9d6f402a',
-            title: 'Valid title (AC-01 #2)',
+            title: 'Second entry',
             date: '2025-02-12'
         });
 

--- a/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
@@ -1,0 +1,44 @@
+// tests/helpers/datasets/ListEntriesDataset.ts
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * UC-2 datasets for frontend gateway tests.
+ *
+ * Purpose:
+ * Provide shared arrays of Entry objects for list scenarios, keeping
+ * AC-01…AC-04 tests consistent and DRY.
+ *
+ * Notes:
+ * - Default sort in UC-2 is "date DESC". The returned array follows
+ *   this order so tests can assert deterministic behavior.
+ */
+export class ListEntriesDataset {
+    /**
+     * AC-01 — Happy Path (default page, no filters).
+     * Returns entries sorted by date DESC.
+     *
+     * @returns {Entry[]} Array of valid entries.
+     */
+    static ac01HappyPath(): Entry[] {
+        const first: Entry = {
+            id: '591aef97-d0ae-4d86-b2cc-2a2ef6a71918',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-14',
+            createdAt: '2025-02-12T10:00:02+00:00',
+            updatedAt: '2025-02-12T10:00:02+00:00'
+        };
+
+        const second: Entry = {
+            id: 'a68b6643-e713-4266-a7d5-8fad9d6f402a',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-12',
+            createdAt: '2025-02-11T09:00:02+00:00',
+            updatedAt: '2025-02-11T09:00:02+00:00'
+        };
+
+        const items: Entry[] = [first, second];
+        return items;
+    }
+}

--- a/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
+++ b/frontend/tests/helpers/datasets/Entries/ListEntriesDataset.ts
@@ -1,5 +1,5 @@
-// tests/helpers/datasets/ListEntriesDataset.ts
 import type {Entry} from '@src/Domain/Entries/Entry';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
  * UC-2 datasets for frontend gateway tests.
@@ -20,23 +20,17 @@ export class ListEntriesDataset {
      * @returns {Entry[]} Array of valid entries.
      */
     static ac01HappyPath(): Entry[] {
-        const first: Entry = {
+        const first = EntryFactory.make({
             id: '591aef97-d0ae-4d86-b2cc-2a2ef6a71918',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-14',
-            createdAt: '2025-02-12T10:00:02+00:00',
-            updatedAt: '2025-02-12T10:00:02+00:00'
-        };
+            title: 'Valid title (AC-01 #1)',
+            date: '2025-02-14'
+        });
 
-        const second: Entry = {
+        const second = EntryFactory.make({
             id: 'a68b6643-e713-4266-a7d5-8fad9d6f402a',
-            title: 'Valid title',
-            body: 'Valid body',
-            date: '2025-02-12',
-            createdAt: '2025-02-11T09:00:02+00:00',
-            updatedAt: '2025-02-11T09:00:02+00:00'
-        };
+            title: 'Valid title (AC-01 #2)',
+            date: '2025-02-12'
+        });
 
         const items: Entry[] = [first, second];
         return items;

--- a/frontend/tests/helpers/factories/EntryFactory.ts
+++ b/frontend/tests/helpers/factories/EntryFactory.ts
@@ -1,5 +1,6 @@
 // tests/helpers/factories/EntryFactory.ts
 import type {Entry} from '@src/Domain/Entries/Entry';
+import {uuidv4} from '@tests/helpers/utils/uuid';
 
 /**
  * Factory for building deterministic Entry objects used in tests.
@@ -21,7 +22,7 @@ export class EntryFactory {
      */
     static make(overrides: Partial<Entry> = {}): Entry {
         const base: Entry = {
-            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
+            id: uuidv4(),
             title: 'Valid title',
             body: 'Valid body',
             date: '2025-02-12',

--- a/frontend/tests/helpers/factories/EntryFactory.ts
+++ b/frontend/tests/helpers/factories/EntryFactory.ts
@@ -1,0 +1,35 @@
+// tests/helpers/factories/EntryFactory.ts
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * Factory for building deterministic Entry objects used in tests.
+ *
+ * Purpose:
+ * Provide a single, reusable generator for Entry domain models
+ * across all datasets (GetEntry, ListEntries, UpdateEntry, etc.).
+ *
+ * Mechanics:
+ * - Produces a valid baseline Entry that satisfies domain rules.
+ * - Accepts partial overrides to change specific fields.
+ */
+export class EntryFactory {
+    /**
+     * Builds a valid Entry object with optional overrides.
+     *
+     * @param {Partial<Entry>} overrides Optional field overrides.
+     * @returns {Entry} Valid Entry object.
+     */
+    static make(overrides: Partial<Entry> = {}): Entry {
+        const base: Entry = {
+            id: '23d90e4f-e736-4260-8c31-ae9124fb9280',
+            title: 'Valid title',
+            body: 'Valid body',
+            date: '2025-02-12',
+            createdAt: '2025-10-04T15:01:18+00:00',
+            updatedAt: '2025-10-04T15:01:18+00:00'
+        };
+
+        const entry: Entry = {...base, ...overrides};
+        return entry;
+    }
+}

--- a/frontend/tests/helpers/http/requests/entries/AddEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/AddEntryRequestFactory.ts
@@ -1,7 +1,5 @@
 // UC-1 AddEntry — Request factory (AC01–AC04).
 // Returns plain request objects without importing types from src.
-
-import type {Entry} from '@src/Domain/Entries/Entry';
 import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
@@ -77,4 +75,3 @@ export function ac04SuccessFalse(): {title: string; body: string; date: string} 
     const payload = {title, body, date};
     return payload;
 }
-

--- a/frontend/tests/helpers/http/requests/entries/AddEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/AddEntryRequestFactory.ts
@@ -1,0 +1,80 @@
+// UC-1 AddEntry — Request factory (AC01–AC04).
+// Returns plain request objects without importing types from src.
+
+import type {Entry} from '@src/Domain/Entries/Entry';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+
+/**
+ * AC-01 — Happy Path payload.
+ *
+ * Builds a request object directly from EntryFactory output.
+ * Extracts title, body, and date via destructuring for consistency
+ * with domain Entry shape.
+ *
+ * @return {{title: string, body: string, date: string}} Valid AddEntry request body.
+ */
+export function ac01HappyPath(): {title: string; body: string; date: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-01)'});
+
+    const {title, body, date} = entry;
+    const payload = {title, body, date};
+
+    return payload;
+}
+
+/**
+ * AC-02 — Non-2xx Response payload.
+ *
+ * Builds a syntactically valid AddEntry request intended
+ * for transport-level error tests (HTTP 400/500).
+ * Extracts only title, body, and date from EntryFactory output
+ * to stay consistent with domain Entry shape.
+ *
+ * @return {{title: string, body: string, date: string}} Valid request for non-2xx tests.
+ */
+export function ac02Non2xxResponse(): {title: string; body: string; date: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-02)'});
+
+    const {title, body, date} = entry;
+
+    const payload = {title, body, date};
+    return payload;
+}
+
+/**
+ * AC-03 — Malformed JSON payload.
+ *
+ * Builds a syntactically valid AddEntry request intended
+ * for tests where the server responds with a malformed JSON body
+ * (e.g., missing data.item or invalid shape).
+ * The request itself is completely valid; only the response is corrupted.
+ *
+ * @return {{title: string, body: string, date: string}} Valid AddEntry request for malformed JSON tests.
+ */
+export function ac03MalformedJson(): {title: string; body: string; date: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-03)'});
+
+    const {title, body, date} = entry;
+
+    const payload = {title, body, date};
+    return payload;
+}
+
+/**
+ * AC-04 — Success=false payload.
+ *
+ * Builds a fully valid AddEntry request used in tests
+ * where the server responds with { success: false } but HTTP status is 200.
+ * The request itself is correct; only the logical outcome differs.
+ *
+ * @return {{title: string, body: string, date: string}} Valid AddEntry request for success=false tests.
+ */
+export function ac04SuccessFalse(): {title: string; body: string; date: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-04)'});
+
+    const {title, body, date} = entry;
+
+    const payload = {title, body, date};
+    return payload;
+}
+

--- a/frontend/tests/helpers/http/responses/common/Non2xxResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/common/Non2xxResponseFactory.ts
@@ -1,0 +1,70 @@
+/**
+ * Common response builders for transport-level (non-2xx) HTTP errors.
+ *
+ * Purpose:
+ * Provide shared JSON payloads for gateway tests simulating network/server failures.
+ *
+ * These responses are NOT UC-specific and do not contain business error codes.
+ * They represent generic HTTP-layer failures (400, 500, 503, etc.).
+ */
+
+/**
+ * Builds a generic transport error payload.
+ *
+ * @param status - HTTP status code (non-2xx)
+ * @param message - optional textual description
+ * @returns object matching the expected error JSON schema
+ */
+export function makeTransportError(status: number, message: string = 'Transport error') {
+    //prettier-ignore
+    const payload = {
+        success: false,
+        status : status,
+        message: message
+    };
+
+    return payload;
+}
+
+/**
+ * 400 Bad Request (generic)
+ *
+ * Use when backend responds with a syntactically invalid request
+ * or malformed payload not tied to a domain rule.
+ */
+export function makeBadRequest() {
+    //prettier-ignore
+    const status  = 400;
+    const message = 'Bad Request';
+    const payload = makeTransportError(status, message);
+
+    return payload;
+}
+
+/**
+ * 500 Internal Server Error
+ *
+ * Use when backend fails internally or returns an unexpected exception.
+ */
+export function makeInternalError() {
+    //prettier-ignore
+    const status  = 500;
+    const message = 'Internal Server Error';
+    const payload = makeTransportError(status, message);
+
+    return payload;
+}
+
+/**
+ * 503 Service Unavailable
+ *
+ * Use when the backend or network layer is temporarily unavailable.
+ */
+export function makeServiceUnavailable() {
+    //prettier-ignore
+    const status  = 503;
+    const message = 'Service Unavailable';
+    const payload = makeTransportError(status, message);
+
+    return payload;
+}

--- a/frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
@@ -1,0 +1,40 @@
+// frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
+// Purpose: build consistent mocked API responses for UC-1 AddEntry gateway tests.
+// No imports from src — only plain JavaScript objects.
+
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+
+/**
+ * AC-01 — Happy Path response.
+ *
+ * Builds a mocked API JSON object corresponding to a successful AddEntry response:
+ *  {
+ *      success: true,
+ *      status: 200,
+ *      data: { item: { ...entry } }
+ *  }
+ *
+ * The provided request must contain title, body, and date.
+ * EntryFactory is used to generate the domain-like object for data.item.
+ *
+ * @param {{title: string, body: string, date: string}} request
+ * @returns {{success: true, status: 200, data: {item: object}}} Mocked API payload.
+ */
+export function ac01HappyPath(request: {title: string; body: string; date: string}) {
+    const title = `${request.title} (UC-01, AC-01)`;
+
+    const item = EntryFactory.make({
+        title,
+        body: request.body,
+        date: request.date
+    });
+
+    // prettier-ignore
+    const payload = {
+        success: true,
+        status : 200,
+        data   : {item}
+    };
+
+    return payload;
+}

--- a/frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
@@ -1,37 +1,24 @@
 // Purpose: provide consistent mocked API responses for UC-1 AddEntry gateway tests.
 import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
-import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 import type {AddEntryRequest} from '@src/Application/DTO/Entries/AddEntry/AddEntryRequest';
 import type {AddEntryResponse} from '@src/Application/DTO/Entries/AddEntry/AddEntryResponse';
 
 /**
  * AC-01 — Happy path.
  *
- * Builds a mocked API response representing a successful AddEntry request.
- * Mirrors the real backend payload:
- *
- * ```json
- * {
- *   "success": true,
- *   "status": 200,
- *   "data": { ...Entry }
- * }
- * ```
- *
- * The request must include valid `title`, `body`, and `date` fields.
- * EntryFactory is used to generate a realistic Entry object.
+ * Builds a mocked AddEntry success response that mirrors backend payload:
+ * {success: true, status: 200, data: Entry}.
  *
  * @param {AddEntryRequest} request Valid AddEntry request payload.
- * @returns {AddEntryResponse} Mocked API payload for a successful entry creation.
+ * @returns {AddEntryResponse} Mocked API payload with created Entry in data.
  */
 export function ac01HappyPath(request: AddEntryRequest): AddEntryResponse {
     const item = EntryFactory.make(request);
 
-    // prettier-ignore
     const response: AddEntryResponse = {
         success: true,
-        status : 200,
-        data   : item
+        status: 200,
+        data: item
     };
 
     return response;
@@ -40,31 +27,53 @@ export function ac01HappyPath(request: AddEntryRequest): AddEntryResponse {
 /**
  * AC-03 — Malformed JSON (structural).
  *
- * Builds a syntactically valid but structurally invalid AddEntry response
- * used to verify gateway validation of malformed payloads.
+ * Builds a syntactically valid payload that violates the success=true branch
+ * of UseCaseResponse by omitting the required `data` field.
+ * Used to ensure the gateway rejects such responses as malformed.
  *
- * The response emulates a 200 OK with `success=true` but missing the `data`
- * object that normally contains the created Entry.
- *
- * ```json
- * {
- *   "success": true,
- *   "status": 200
- * }
- * ```
- *
- * @param {AddEntryRequest} _request Accepted for signature consistency; intentionally unused.
- * @returns {UseCaseResponse<unknown>} Mocked malformed response to trigger gateway rejection.
+ * @typedef MalformedAddEntrySuccessPayload
+ * A payload with success=true and missing `data` on purpose.
  */
-export function ac03MalformedJson(_request: AddEntryRequest): UseCaseResponse<unknown> {
+export interface MalformedAddEntrySuccessPayload {
+    success: true;
+    status: number;
+    // intentionally no `data`
+}
+
+/**
+ * @param {AddEntryRequest} _request Accepted for signature consistency; intentionally unused.
+ * @returns {MalformedAddEntrySuccessPayload} success=true payload without `data`.
+ */
+export function ac03MalformedJson(_request: AddEntryRequest): MalformedAddEntrySuccessPayload {
+    void _request;
+
+    const payload: MalformedAddEntrySuccessPayload = {
+        success: true,
+        status: 200
+        // intentionally missing `data`
+    };
+
+    return payload;
+}
+
+/**
+ * AC-04 — success=false with HTTP 200.
+ *
+ * Builds a syntactically valid response where success is false.
+ * Used to assert that the gateway rejects even when status is 200.
+ *
+ * @param _request {AddEntryRequest} accepted for signature symmetry; intentionally unused.
+ * @returns {AddEntryResponse} mocked payload with success=false.
+ */
+export function ac04SuccessFalse(_request: AddEntryRequest): AddEntryResponse {
     void _request;
 
     // prettier-ignore
     const payload: AddEntryResponse = {
-        success: true,
-        status : 200
-        // intentionally missing data
-    };
+        success: false,
+        status : 200,
+        // no data on error responses in our contract
+    }
 
     return payload;
 }

--- a/frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
@@ -1,39 +1,69 @@
-// frontend/tests/helpers/http/responses/entries/AddEntryResponseFactory.ts
-// Purpose: build consistent mocked API responses for UC-1 AddEntry gateway tests.
-// No imports from src — only plain JavaScript objects.
-
+// Purpose: provide consistent mocked API responses for UC-1 AddEntry gateway tests.
 import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {AddEntryRequest} from '@src/Application/DTO/Entries/AddEntry/AddEntryRequest';
+import type {AddEntryResponse} from '@src/Application/DTO/Entries/AddEntry/AddEntryResponse';
 
 /**
- * AC-01 — Happy Path response.
+ * AC-01 — Happy path.
  *
- * Builds a mocked API JSON object corresponding to a successful AddEntry response:
- *  {
- *      success: true,
- *      status: 200,
- *      data: { item: { ...entry } }
- *  }
+ * Builds a mocked API response representing a successful AddEntry request.
+ * Mirrors the real backend payload:
  *
- * The provided request must contain title, body, and date.
- * EntryFactory is used to generate the domain-like object for data.item.
+ * ```json
+ * {
+ *   "success": true,
+ *   "status": 200,
+ *   "data": { ...Entry }
+ * }
+ * ```
  *
- * @param {{title: string, body: string, date: string}} request
- * @returns {{success: true, status: 200, data: {item: object}}} Mocked API payload.
+ * The request must include valid `title`, `body`, and `date` fields.
+ * EntryFactory is used to generate a realistic Entry object.
+ *
+ * @param {AddEntryRequest} request Valid AddEntry request payload.
+ * @returns {AddEntryResponse} Mocked API payload for a successful entry creation.
  */
-export function ac01HappyPath(request: {title: string; body: string; date: string}) {
-    const title = `${request.title} (UC-01, AC-01)`;
-
-    const item = EntryFactory.make({
-        title,
-        body: request.body,
-        date: request.date
-    });
+export function ac01HappyPath(request: AddEntryRequest): AddEntryResponse {
+    const item = EntryFactory.make(request);
 
     // prettier-ignore
-    const payload = {
+    const response: AddEntryResponse = {
         success: true,
         status : 200,
-        data   : {item}
+        data   : item
+    };
+
+    return response;
+}
+
+/**
+ * AC-03 — Malformed JSON (structural).
+ *
+ * Builds a syntactically valid but structurally invalid AddEntry response
+ * used to verify gateway validation of malformed payloads.
+ *
+ * The response emulates a 200 OK with `success=true` but missing the `data`
+ * object that normally contains the created Entry.
+ *
+ * ```json
+ * {
+ *   "success": true,
+ *   "status": 200
+ * }
+ * ```
+ *
+ * @param {AddEntryRequest} _request Accepted for signature consistency; intentionally unused.
+ * @returns {UseCaseResponse<unknown>} Mocked malformed response to trigger gateway rejection.
+ */
+export function ac03MalformedJson(_request: AddEntryRequest): UseCaseResponse<unknown> {
+    void _request;
+
+    // prettier-ignore
+    const payload: AddEntryResponse = {
+        success: true,
+        status : 200
+        // intentionally missing data
     };
 
     return payload;

--- a/frontend/tests/helpers/utils/uuid.ts
+++ b/frontend/tests/helpers/utils/uuid.ts
@@ -1,0 +1,16 @@
+/**
+ * Simple UUID v4 generator for test data.
+ *
+ * Purpose:
+ * Produce pseudo-random UUIDs using only built-in JS functions.
+ * Not cryptographically secure, but sufficient for test fixtures.
+ *
+ * @returns {string} UUID v4 string, e.g. "3f6f38d2-9a2a-4c9b-b821-7a5a1b93a3d4".
+ */
+export function uuidv4(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+}

--- a/frontend/tests/helpers/utils/uuid.ts
+++ b/frontend/tests/helpers/utils/uuid.ts
@@ -8,7 +8,7 @@
  * @returns {string} UUID v4 string, e.g. "3f6f38d2-9a2a-4c9b-b821-7a5a1b93a3d4".
  */
 export function uuidv4(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
         const r = (Math.random() * 16) | 0;
         const v = c === 'x' ? r : (r & 0x3) | 0x8;
         return v.toString(16);

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
         globals: true,
         include: ['tests/**/*.test.ts'],
         reporters: ['default'],
-        testTimeout: 5000
+        testTimeout: 5000,
+        silent: false
     }
 });


### PR DESCRIPTION
Creates AddEntry gateway and related tests to align with backend response shape and new discriminated UseCaseResponse type.

Introduces clean typing for success and error branches, and adds AC-04 (success=false) test coverage.

Resolves #17 