### PR TITLE
feat(frontend): unify UC-2/UC-3 gateways with typed transport & test suites

### DIFF
--- a/frontend/src/Application/DTO/Entries/GetEntry/GetEntryRequest.ts
+++ b/frontend/src/Application/DTO/Entries/GetEntry/GetEntryRequest.ts
@@ -1,0 +1,13 @@
+/**
+ * UC-3: Get Entry — request DTO.
+ *
+ * Describes the path parameter required by /api/entries/:id.
+ * The gateway will serialize this DTO by substituting {id} into the URL.
+ */
+export type GetEntryRequest = {
+    /**
+     * Entry identifier (UUID v4 as produced by backend).
+     * Validation of format/semantics is out of scope for the gateway DTO.
+     */
+    id: string;
+};

--- a/frontend/src/Application/DTO/Entries/GetEntry/GetEntryResponse.ts
+++ b/frontend/src/Application/DTO/Entries/GetEntry/GetEntryResponse.ts
@@ -1,0 +1,12 @@
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+
+/**
+ * UC-3: Get Entry — response DTO.
+ *
+ * Mirrors backend payload exactly:
+ * { success: true, status: 200, data: Entry }.
+ *
+ * Logical errors (e.g., ENTRY_NOT_FOUND) return { success:false, status:404, code:"..." }.
+ */
+export type GetEntryResponse = UseCaseResponse<Entry>;

--- a/frontend/src/Application/DTO/Entries/ListEntries/ListEntriesRequest.ts
+++ b/frontend/src/Application/DTO/Entries/ListEntries/ListEntriesRequest.ts
@@ -1,9 +1,41 @@
-import type {Entry} from '@src/Domain/Entries/Entry';
+/**
+ * UC-2: List Entries — request DTO.
+ *
+ * Describes query parameters accepted by /api/entries.
+ * The gateway serializes this DTO into a query string.
+ * - `query` accepts a single string.
+ * - Date range uses strict YYYY-MM-DD (backend validates semantics).
+ * - Sorting is explicit to prevent accidental typos.
+ */
+export type ListEntriesRequest = {
+    /**
+     * Free-text search.
+     */
+    query?: string;
 
-export type ListEntriesData = {
-    items: Entry[];
-    page: number;
-    perPage: number;
-    total: number;
-    pagesCount: number;
+    /**
+     * 1-based page index.
+     */
+    page?: number;
+
+    /**
+     * Page size.
+     */
+    perPage?: number;
+
+    /**
+     * Sort field allowed by backend contract.
+     */
+    sortField?: 'date' | 'updatedAt';
+
+    /**
+     * Sort direction.
+     */
+    sortDir?: 'ASC' | 'DESC';
+
+    /**
+     * Inclusive date range (YYYY-MM-DD).
+     */
+    dateFrom?: string;
+    dateTo?: string;
 };

--- a/frontend/src/Application/DTO/Entries/ListEntries/ListEntriesResponse.ts
+++ b/frontend/src/Application/DTO/Entries/ListEntries/ListEntriesResponse.ts
@@ -1,12 +1,22 @@
 import type {Entry} from '@src/Domain/Entries/Entry';
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 
-export interface ListEntriesData {
+/**
+ * UC-2: List Entries — response DTO.
+ *
+ * Mirrors backend payload exactly:
+ * { success: true, status: 200, data: { items, page, perPage, total, pagesCount } }.
+ * Pagination fields are top-level inside `data` (no nested `pagination` object).
+ */
+export type ListEntriesData = {
     items: Entry[];
     page: number;
     perPage: number;
     total: number;
     pagesCount: number;
-}
+};
 
-export interface ListEntriesResponse extends UseCaseResponse<ListEntriesData> {}
+/**
+ * Discriminated transport envelope for UC-2.
+ */
+export type ListEntriesResponse = UseCaseResponse<ListEntriesData>;

--- a/frontend/src/Infrastructure/Entries/GetEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/GetEntryGateway.ts
@@ -1,17 +1,19 @@
 import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
 import type {Entry} from '@src/Domain/Entries/Entry';
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {GetEntryRequest} from '@src/Application/DTO/Entries/GetEntry/GetEntryRequest';
 
 /**
  * UC-3: Get Entry (Frontend)
  *
- * Fetches a single entry by ID from /api/entries/:id.
- * Performs minimal transport-level validation:
- * - res.ok must be true;
- * - success must be true;
- * - data.item must be a non-null object.
+ * Fetches a single entry by ID from GET /api/entries/:id.
  *
- * Does not validate Entry fields (handled in higher layers).
+ * Transport-level validation:
+ * - HTTP must be ok (delegated to HttpClient);
+ * - response.success must be true;
+ * - response.data must be a non-null object (Entry).
+ *
+ * Field-level validation is out of scope here (handled by backend/higher layers).
  */
 export class GetEntryGateway {
     private readonly http: HttpClient;
@@ -20,19 +22,32 @@ export class GetEntryGateway {
         this.http = http;
     }
 
-    async get(id: string): Promise<Entry> {
-        const url = `/api/entries/${id}`;
-        const json = await this.http.request<UseCaseResponse<{item: Entry}>>('GET', url);
+    /**
+     * UC-3: Get Entry (Gateway)
+     *
+     * Performs GET /api/entries/{id} and returns the Entry from response.data.
+     *
+     * @param {GetEntryRequest} req Path parameter with entry ID.
+     * @returns {Promise<Entry>} Resolved entry object from backend.
+     * @throws {Error} If HTTP is non-2xx or the transport envelope is malformed.
+     */
+    async get(req: GetEntryRequest): Promise<Entry> {
+        const url = `/api/entries/${req.id}`;
+        const json = await this.http.request<UseCaseResponse<Entry>>('GET', url);
 
-        const ok = json?.success === true;
-        const hasItem = typeof json?.data?.item === 'object' && json.data.item !== null;
-
-        if (!ok || !hasItem) {
+        if (json.success !== true) {
             const message = 'Malformed response for GET /api/entries/:id';
             throw new Error(message);
         }
 
-        const entry = json.data!.item;
+        const hasData = typeof json.data === 'object' && json.data !== null;
+        if (!hasData) {
+            const message = 'Malformed response for GET /api/entries/:id';
+            throw new Error(message);
+        }
+
+        const entry = json.data as Entry;
+
         return entry;
     }
 }

--- a/frontend/src/Infrastructure/Entries/ListEntriesGateway.ts
+++ b/frontend/src/Infrastructure/Entries/ListEntriesGateway.ts
@@ -1,30 +1,122 @@
 import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
 import type {Entry} from '@src/Domain/Entries/Entry';
-import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
-import type {ListEntriesData} from '@src/Application/DTO/Entries/ListEntries/ListEntriesRequest';
+import type {ListEntriesRequest} from '@src/Application/DTO/Entries/ListEntries/ListEntriesRequest';
+import type {
+    ListEntriesData,
+    ListEntriesResponse
+} from '@src/Application/DTO/Entries/ListEntries/ListEntriesResponse';
 
-export class HttpEntriesGateway {
+/**
+ * UC-2: List Entries (Frontend)
+ *
+ * Fetches a paginated list of entries from GET /api/entries with query params.
+ *
+ * Transport-level validation:
+ * - HTTP must be ok (delegated to HttpClient);
+ * - response.success must be true;
+ * - response.data must be a non-null object;
+ * - response.data.items must be an array;
+ * - pagination scalars (page, perPage, total, pagesCount) must be numbers.
+ *
+ * Field-level validation of Entry is out of scope (handled by backend/higher layers).
+ */
+export class ListEntriesGateway {
     private readonly http: HttpClient;
 
     constructor(http: HttpClient) {
         this.http = http;
     }
 
-    async list(): Promise<Entry[]> {
-        const json = await this.http.request<UseCaseResponse<ListEntriesData>>(
-            'GET',
-            '/api/entries'
-        );
+    /**
+     * UC-2: List Entries (Gateway)
+     *
+     * Performs GET /api/entries with serialized query string built from ListEntriesRequest.
+     * Returns the `data` object (items + pagination) from the backend envelope.
+     *
+     * @param {ListEntriesRequest} req Query parameters to filter/sort/paginate entries.
+     * @returns {Promise<ListEntriesData>} Items with pagination as provided by backend.
+     * @throws {Error} If HTTP is non-2xx or the transport envelope is malformed.
+     */
+    async list(req: ListEntriesRequest = {}): Promise<ListEntriesData> {
+        const url = this.buildUrl('/api/entries', req);
 
-        const ok = json?.success === true;
-        const hasItems = Array.isArray(json?.data?.items);
+        const json = await this.http.request<ListEntriesResponse>('GET', url);
 
-        if (!ok || !hasItems) {
+        if (json.success !== true) {
             const message = 'Malformed response for GET /api/entries';
             throw new Error(message);
         }
 
-        const items = json.data!.items;
-        return items;
+        const dataOk = typeof json.data === 'object' && json.data !== null;
+        if (!dataOk) {
+            const message = 'Malformed response for GET /api/entries';
+            throw new Error(message);
+        }
+
+        const {items, page, perPage, total, pagesCount} = json.data as ListEntriesData;
+
+        const itemsIsArray = Array.isArray(items);
+        const scalarsOk =
+            typeof page === 'number' &&
+            typeof perPage === 'number' &&
+            typeof total === 'number' &&
+            typeof pagesCount === 'number';
+
+        if (!itemsIsArray || !scalarsOk) {
+            const message = 'Malformed response for GET /api/entries';
+            throw new Error(message);
+        }
+
+        const result: ListEntriesData = {
+            items: items as Entry[],
+            page,
+            perPage,
+            total,
+            pagesCount
+        };
+
+        return result;
+    }
+
+    /**
+     * Serializes ListEntriesRequest into a query string.
+     * - `query` may be string or string[] (maps to ?query=... or ?query[]=...).
+     * - Omits undefined fields.
+     * - Uses strict key names matching backend contract.
+     *
+     * @param {string} base Base path (/api/entries).
+     * @param {ListEntriesRequest} req Request with optional filters/sort/pagination.
+     * @returns {string} Fully composed URL with query string, or base if empty.
+     */
+    private buildUrl(base: string, req: ListEntriesRequest): string {
+        const params = new URLSearchParams();
+
+        if (typeof req.query === 'string') {
+            params.append('query', req.query);
+        }
+
+        if (typeof req.page === 'number') {
+            params.append('page', String(req.page));
+        }
+        if (typeof req.perPage === 'number') {
+            params.append('perPage', String(req.perPage));
+        }
+        if (typeof req.sortField === 'string') {
+            params.append('sortField', req.sortField);
+        }
+        if (typeof req.sortDir === 'string') {
+            params.append('sortDir', req.sortDir);
+        }
+        if (typeof req.dateFrom === 'string') {
+            params.append('dateFrom', req.dateFrom);
+        }
+        if (typeof req.dateTo === 'string') {
+            params.append('dateTo', req.dateTo);
+        }
+
+        const query = params.toString();
+        const url = query ? `${base}?${query}` : base;
+
+        return url;
     }
 }

--- a/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
@@ -1,10 +1,25 @@
-// frontend/tests/Unit/Entries/GetEntry/Http/AC01_HappyPath.test.ts
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
-import {okGet} from '@tests/helpers/api-responses/UC-3-GetEntry';
-import {GetEntryDataset} from '@tests/helpers/datasets/Entries/GetEntryDataset';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/GetEntryRequestFactory';
+import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/GetEntryResponseFactory';
 
-describe('AC01 — HttpGetEntryGateway returns entry on 200 JSON { data.item: {...} }', () => {
+/**
+ * UC-3: Get Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that GetEntryGateway resolves with Entry when API responds
+ * 200 + { success: true, data: Entry }.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals at the call site).
+ * - Build a matching response via response factory from the same request.
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert the gateway returns Entry consistent with response.data.
+ *
+ * Cases covered:
+ * - AC-01 — Happy path with well-formed JSON and success=true.
+ */
+describe('AC01 — GetEntryGateway returns entry (mocked)', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -15,18 +30,22 @@ describe('AC01 — HttpGetEntryGateway returns entry on 200 JSON { data.item: {.
         ctx.cleanup();
     });
 
-    it('returns entry when API responds with { success: true, data.item: {...} }', async () => {
-        const item = GetEntryDataset.ac01HappyPath();
-        const payload = okGet(item);
+    it('returns entry when called with valid id', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request);
 
-        mockJsonOnce(ctx.fetchMock, 200, payload);
+        mockJsonOnce(ctx.fetchMock, 200, response);
 
-        const entry = await ctx.gw.get(item.id);
+        // Act
+        const entry = await ctx.gw.get(request);
 
-        expect(entry.id).toBe(item.id);
-        expect(entry.title).toBe(item.title);
-        expect(entry.body).toBe(item.body);
-
+        // Assert
+        expect(entry.id).toBe(request.id);
+        expect(entry.title).toBe(response.data.title);
+        expect(entry.body).toBe(response.data.body);
+        expect(entry.date).toBe(response.data.date);
         expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC02_Non2xxResponse.test.ts
@@ -1,7 +1,27 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
-import {createGateway, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
+import {ac02Non2xxResponse as makeRequest} from '@tests/helpers/http/requests/entries/GetEntryRequestFactory';
+import {
+    makeBadRequest,
+    makeInternalError
+} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
 
-describe('AC02 — HttpGetEntryGateway throws on non-2xx response', () => {
+/**
+ * UC-3: Get Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that GetEntryGateway rejects on generic non-2xx HTTP responses.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals).
+ * - Use common non-2xx response factories (no domain codes asserted here).
+ * - Mock fetch with 400/500 and assert rejection.
+ *
+ * Cases:
+ * - AC-02a — 400 Bad Request → rejects.
+ * - AC-02b — 500 Internal Server Error → rejects.
+ */
+describe('AC02 — GetEntryGateway throws on non-2xx response (generic)', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -12,35 +32,35 @@ describe('AC02 — HttpGetEntryGateway throws on non-2xx response', () => {
         ctx.cleanup();
     });
 
-    it('throws when API responds 404', async () => {
-        const res = new Response('{}', {
-            status: 404,
-            headers: {
-                'content-type': 'application/json'
-            }
-        });
+    it('throws when API responds with 400 Bad Request', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeBadRequest();
 
-        ctx.fetchMock.mockResolvedValueOnce(res);
+        mockJsonOnce(ctx.fetchMock, 400, response);
 
-        const fn = ctx.gw.get('missing-id');
-        const message = /HTTP 404/;
+        // Act
+        const fn = ctx.gw.get(request);
+        const message = /400|bad request/i;
 
-        await expect(fn).rejects.toThrow(message);
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
     });
 
-    it('throws when API responds 500', async () => {
-        const res = new Response('{}', {
-            status: 500,
-            headers: {
-                'content-type': 'application/json'
-            }
-        });
+    it('throws when API responds with 500 Internal Server Error', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeInternalError();
 
-        ctx.fetchMock.mockResolvedValueOnce(res);
+        mockJsonOnce(ctx.fetchMock, 500, response);
 
-        const fn = ctx.gw.get('any');
-        const message = /HTTP 500/;
+        // Act
+        const fn = ctx.gw.get(request);
+        const message = /500|internal/i;
 
-        await expect(fn).rejects.toThrow(message);
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC03_MalformedJson.test.ts
@@ -1,8 +1,25 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
-import {okMalformedGetWithoutItem} from '@tests/helpers/api-responses/UC-3-GetEntry';
+import {ac03MalformedJson as makeRequest} from '@tests/helpers/http/requests/entries/GetEntryRequestFactory';
+import {ac03MalformedJson as makeResponse} from '@tests/helpers/http/responses/entries/GetEntryResponseFactory';
 
-describe('AC03 — HttpGetEntryGateway throws on malformed JSON (no data.item)', () => {
+/**
+ * UC-3: Get Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that GetEntryGateway rejects when API responds with a malformed JSON body,
+ * i.e. success=true but missing required `data` property.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals at the call site).
+ * - Build a malformed success response via response factory (no `data`).
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert the gateway rejects with a Malformed* style error.
+ *
+ * Cases covered:
+ * - AC-03 — Malformed JSON (success=true without `data`).
+ */
+describe('AC03 — GetEntryGateway rejects on malformed JSON (missing data)', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -13,12 +30,19 @@ describe('AC03 — HttpGetEntryGateway throws on malformed JSON (no data.item)',
         ctx.cleanup();
     });
 
-    it('throws when API returns JSON without data.item object', async () => {
-        mockJsonOnce(ctx.fetchMock, 200, okMalformedGetWithoutItem());
+    it('throws when success=true but `data` is missing', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:true, no data
 
-        const fn = ctx.gw.get('any-id');
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        // Act
+        const fn = ctx.gw.get(request);
         const message = 'Malformed response for GET /api/entries/:id';
 
-        await expect(fn).rejects.toThrow(message);
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
@@ -1,9 +1,25 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
-import {GetEntryDataset} from '@tests/helpers/datasets/Entries/GetEntryDataset';
-import {successFalseGet} from '@tests/helpers/api-responses/UC-3-GetEntry';
+import {ac04SuccessFalse as makeRequest} from '@tests/helpers/http/requests/entries/GetEntryRequestFactory';
+import {ac04SuccessFalse as makeResponse} from '@tests/helpers/http/responses/entries/GetEntryResponseFactory';
 
-describe('AC04 — HttpGetEntryGateway throws when success=false even on 200 OK', () => {
+/**
+ * UC-3: Get Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that GetEntryGateway rejects when API responds with { success:false }
+ * even though HTTP status is 200.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Build a mocked response with success=false via response factory.
+ * - Mock HTTP once with status 200 and the error-like payload.
+ * - Assert that the gateway rejects with a descriptive error.
+ *
+ * Cases covered:
+ * - AC-04 — success=false (logical failure).
+ */
+describe('AC04 — GetEntryGateway rejects when success=false with 200 OK', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -14,15 +30,19 @@ describe('AC04 — HttpGetEntryGateway throws when success=false even on 200 OK'
         ctx.cleanup();
     });
 
-    it('throws when API returns 200 OK but success=false', async () => {
-        const item = GetEntryDataset.ac04SuccessFalse();
-        const payload = successFalseGet(item);
+    it('throws when API responds with success=false despite 200 status', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:false
 
-        mockJsonOnce(ctx.fetchMock, 200, payload);
+        mockJsonOnce(ctx.fetchMock, 200, response);
 
-        const fn = ctx.gw.get(item.id);
+        // Act
+        const fn = ctx.gw.get(request);
         const message = 'Malformed response for GET /api/entries/:id';
 
-        await expect(fn).rejects.toThrow(message);
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/BaseGetEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/BaseGetEntryGatewayTest.ts
@@ -6,8 +6,13 @@ export type GatewayTestCtx = HttpTestCtxBase & {
 };
 
 /**
- * Provides a fresh GetEntryGateway built over shared HTTP test context.
+ * Provides a mocked GetEntryGateway built over the shared HTTP test context.
  * The caller is responsible for calling ctx.cleanup() in afterEach().
+ *
+ * Mechanics:
+ * - Reuses the base HTTP mock context (fetchMock, http, cleanup).
+ * - Builds a gateway instance over the mocked HttpClient.
+ * - Re-exports mock helpers from the common base for consistency.
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
     const base = createHttpCtx(baseUrl);

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
@@ -1,9 +1,25 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
-import {okList} from '@tests/helpers/api-responses/UC-2-ListEntries';
-import {ListEntriesDataset} from '@tests/helpers/datasets/Entries/ListEntriesDataset';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
+import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/ListEntriesResponseFactory';
 
-describe('AC01 — HttpListEntriesGateway returns items on 200 JSON { data.items: [...] }', () => {
+/**
+ * UC-2: List Entries (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that ListEntriesGateway resolves with { items[], page, perPage, total, pagesCount }
+ * when API responds 200 + { success:true, data:{...} }.
+ *
+ * Mechanics:
+ * - Build a valid query request via request factory (no literals at the call site).
+ * - Build a matching success response via response factory from the same request.
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert the gateway returns data consistent with the response.
+ *
+ * Cases covered:
+ * - AC-01 — Happy path with well-formed JSON and success=true.
+ */
+describe('AC01 — ListEntriesGateway returns items with pagination (mocked)', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -14,17 +30,34 @@ describe('AC01 — HttpListEntriesGateway returns items on 200 JSON { data.items
         ctx.cleanup();
     });
 
-    it('returns items with default sort by date DESC', async () => {
-        const items = ListEntriesDataset.ac01HappyPath();
-        const payload = okList(items);
+    it('returns items[] and pagination fields on success=true', async () => {
+        // Arrange
+        const request = makeRequest();
+        const response = makeResponse(request); // success:true, data:{items[], page, perPage, total, pagesCount}
+        mockJsonOnce(ctx.fetchMock, 200, response);
 
-        mockJsonOnce(ctx.fetchMock, 200, payload);
+        // Act
+        const data = await ctx.gw.list(request);
 
-        // gw.list returns Entry[]
-        const list = await ctx.gw.list();
+        // Assert — pagination scalars
+        expect(data.page).toBe(response.data.page);
+        expect(data.perPage).toBe(response.data.perPage);
+        expect(data.total).toBe(response.data.total);
+        expect(data.pagesCount).toBe(response.data.pagesCount);
 
-        expect(list.length).toBe(items.length);
-        expect(list[0].id).toBe(items[0].id);
-        expect(list[1].id).toBe(items[1].id);
+        // Assert — items[]
+        expect(Array.isArray(data.items)).toBe(true);
+        expect(data.items.length).toBe(response.data.items.length);
+
+        if (data.items.length > 0) {
+            const first = data.items[0];
+            const firstRef = response.data.items[0];
+
+            expect(first.id).toBe(firstRef.id);
+            expect(first.title).toBe(firstRef.title);
+            expect(first.body).toBe(firstRef.body);
+            expect(first.date).toBe(firstRef.date);
+            expect(first.createdAt <= first.updatedAt).toBe(true);
+        }
     });
 });

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC02_Non2xxResponse.test.ts
@@ -1,7 +1,24 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
-import {createGateway, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
+import {ac02Non2xxResponse as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
+import {makeBadRequest, makeInternalError} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
 
-describe('AC02 — HttpEntriesGateway throws on non-2xx response', () => {
+/**
+ * UC-2: List Entries (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that ListEntriesGateway rejects on generic non-2xx HTTP responses.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Use common non-2xx response factories (no domain codes asserted here).
+ * - Mock fetch with 400/500 and assert rejection.
+ *
+ * Cases:
+ * - AC-02a — 400 Bad Request → rejects.
+ * - AC-02b — 500 Internal Server Error → rejects.
+ */
+describe('AC02 — ListEntriesGateway throws on non-2xx response (generic)', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -12,19 +29,27 @@ describe('AC02 — HttpEntriesGateway throws on non-2xx response', () => {
         ctx.cleanup();
     });
 
-    it('throws when API responds 500', async () => {
-        const res = new Response('{}', {
-            status: 500,
-            headers: {
-                'content-type': 'application/json'
-            }
-        });
+    it('throws when API responds with 400 Bad Request', async () => {
+        const request = makeRequest();
+        const response = makeBadRequest();
 
-        ctx.fetchMock.mockResolvedValueOnce(res);
+        mockJsonOnce(ctx.fetchMock, 400, response);
 
-        const fn = ctx.gw.list();
-        const message = /HTTP 500/;
+        const fn = ctx.gw.list(request);
+        const message = /400|bad request/i;
 
-        await expect(fn).rejects.toThrow(message);
+        await expect(fn).rejects.toThrowError(message);
+    });
+
+    it('throws when API responds with 500 Internal Server Error', async () => {
+        const request = makeRequest();
+        const response = makeInternalError();
+
+        mockJsonOnce(ctx.fetchMock, 500, response);
+
+        const fn = ctx.gw.list(request);
+        const message = /500|internal/i;
+
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC03_MalformedJson.test.ts
@@ -1,8 +1,25 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
-import {okMalformedListWithoutItems} from '@tests/helpers/api-responses/UC-2-ListEntries';
+import {ac03MalformedJson as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
+import {ac03MalformedJson as makeResponse} from '@tests/helpers/http/responses/entries/ListEntriesResponseFactory';
 
-describe('AC03 — HttpEntriesGateway throws on malformed JSON shape (no data.items)', () => {
+/**
+ * UC-2: List Entries (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that ListEntriesGateway rejects when API responds with a malformed JSON body,
+ * i.e. success=true but `data.items` is missing or has wrong shape.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals).
+ * - Build a malformed success response via response factory (no `items`).
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert the gateway rejects with a Malformed* style error.
+ *
+ * Case:
+ * - AC-03 — Malformed JSON (success=true with malformed data).
+ */
+describe('AC03 — ListEntriesGateway rejects on malformed JSON (missing items)', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -13,12 +30,16 @@ describe('AC03 — HttpEntriesGateway throws on malformed JSON shape (no data.it
         ctx.cleanup();
     });
 
-    it('throws when API returns JSON without items array', async () => {
-        mockJsonOnce(ctx.fetchMock, 200, okMalformedListWithoutItems);
+    it('throws when success=true but `data.items` is missing', async () => {
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:true, but malformed data (no items)
 
-        const fn = ctx.gw.list();
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        const fn = ctx.gw.list(request);
         const message = 'Malformed response for GET /api/entries';
 
-        await expect(fn).rejects.toThrow(message);
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC04_SuccessFalse.test.ts
@@ -1,8 +1,25 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
-import {successFalse} from '@tests/helpers/api-responses/UC-2-ListEntries';
+import {ac04SuccessFalse as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
+import {ac04SuccessFalse as makeResponse} from '@tests/helpers/http/responses/entries/ListEntriesResponseFactory';
 
-describe('AC04 — HttpEntriesGateway throws when success=false (even with 200)', () => {
+/**
+ * UC-2: List Entries (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that ListEntriesGateway rejects when API responds with { success:false }
+ * even though HTTP status is 200.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Build a mocked response with success=false via response factory.
+ * - Mock HTTP once with status 200 and the error-like payload.
+ * - Assert that the gateway rejects with a descriptive error.
+ *
+ * Case:
+ * - AC-04 — success=false (logical failure).
+ */
+describe('AC04 — ListEntriesGateway rejects when success=false with 200 OK', () => {
     let ctx: GatewayTestCtx;
 
     beforeEach(() => {
@@ -13,12 +30,16 @@ describe('AC04 — HttpEntriesGateway throws when success=false (even with 200)'
         ctx.cleanup();
     });
 
-    it('throws on success=false', async () => {
-        mockJsonOnce(ctx.fetchMock, 200, successFalse);
+    it('throws when API responds with success=false despite 200 status', async () => {
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:false
 
-        const fn = ctx.gw.list();
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        const fn = ctx.gw.list(request);
         const message = 'Malformed response for GET /api/entries';
 
-        await expect(fn).rejects.toThrow(message);
+        await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/BaseListEntriesGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/BaseListEntriesGatewayTest.ts
@@ -1,17 +1,22 @@
 import {type HttpTestCtxBase, createHttpCtx} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
-import {HttpEntriesGateway} from '@src/Infrastructure/Entries/ListEntriesGateway';
+import {ListEntriesGateway} from '@src/Infrastructure/Entries/ListEntriesGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
-    gw: HttpEntriesGateway;
+    gw: ListEntriesGateway;
 };
 
 /**
- * Provides a fresh ListEntriesGateway built over shared HTTP test context.
- * The caller is responsible for calling ctx.cleanup() in afterEach().
+ * Provides a mocked ListEntriesGateway built over the shared HTTP test context.
+ * The caller must call ctx.cleanup() in afterEach().
+ *
+ * Mechanics:
+ * - Reuses the base HTTP mock context (fetchMock, http, cleanup).
+ * - Builds a gateway instance over the mocked HttpClient.
+ * - Re-exports mock helpers for consistency across gateway suites.
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
     const base = createHttpCtx(baseUrl);
-    const gw = new HttpEntriesGateway(base.http);
+    const gw = new ListEntriesGateway(base.http);
 
     const ctx: GatewayTestCtx = {
         ...base,
@@ -21,5 +26,4 @@ export function createGateway(baseUrl: string = 'http://localhost'): GatewayTest
     return ctx;
 }
 
-// Re-export helper for convenience in old tests.
 export {mockJsonOnce} from '@tests/Unit/Entries/BaseEntriesGatewayTest';

--- a/frontend/tests/helpers/http/requests/entries/GetEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/GetEntryRequestFactory.ts
@@ -1,0 +1,72 @@
+// UC-3 GetEntry — Request factory (AC01–AC04).
+// Returns plain request objects without importing types from src.
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+
+/**
+ * AC-01 — Happy Path request.
+ *
+ * Builds a request object with a valid UUID taken from EntryFactory.
+ * This mirrors real-world usage where the client already knows the entry ID.
+ *
+ * @returns {{id: string}} Valid GetEntry request payload.
+ */
+export function ac01HappyPath(): {id: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-01)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
+}
+
+/**
+ * AC-02 — Non-2xx Response request.
+ *
+ * Builds a syntactically valid request used for transport-level error tests
+ * (e.g., 400/404/500). The request itself is correct; only HTTP status differs.
+ *
+ * @returns {{id: string}} Valid request for non-2xx scenarios.
+ */
+export function ac02Non2xxResponse(): {id: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-02)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
+}
+
+/**
+ * AC-03 — Malformed JSON request.
+ *
+ * Builds a valid request intended for tests where the server responds
+ * with a malformed JSON body (e.g., missing `data` even though success=true).
+ * The request is valid by design.
+ *
+ * @returns {{id: string}} Valid request for malformed JSON scenarios.
+ */
+export function ac03MalformedJson(): {id: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-03)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
+}
+
+/**
+ * AC-04 — success=false request.
+ *
+ * Builds a valid request used in tests where the API responds with
+ * { success:false } and HTTP status 200 (logical failure branch).
+ *
+ * @returns {{id: string}} Valid request for success=false scenarios.
+ */
+export function ac04SuccessFalse(): {id: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-04)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
+}

--- a/frontend/tests/helpers/http/requests/entries/ListEntriesRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/ListEntriesRequestFactory.ts
@@ -1,0 +1,104 @@
+// UC-2 ListEntries — Request factory (AC01–AC04).
+// Returns plain request objects without importing types from src.
+
+/**
+ * AC-01 — Happy Path request.
+ *
+ * Builds a valid query with explicit pagination and sorting.
+ * Mirrors a typical client request to fetch the latest entries by updatedAt.
+ *
+ * @returns {{
+ *   query?: string,
+ *   page?: number,
+ *   perPage?: number,
+ *   sortField?: 'date'|'updatedAt',
+ *   sortDir?: 'ASC'|'DESC',
+ *   dateFrom?: string,
+ *   dateTo?: string
+ * }} Valid ListEntries request.
+ */
+export function ac01HappyPath(): {
+    query?: string;
+    page?: number;
+    perPage?: number;
+    sortField?: 'date' | 'updatedAt';
+    sortDir?: 'ASC' | 'DESC';
+    dateFrom?: string;
+    dateTo?: string;
+} {
+    // prettier-ignore
+    {
+        const query     = 'hello';
+        const page      = 1;
+        const perPage   = 10;
+        const sortField = 'updatedAt' as const;
+        const sortDir   = 'DESC' as const;
+
+        const payload = {query, page, perPage, sortField, sortDir};
+
+        return payload;
+    }
+}
+
+/**
+ * AC-02 — Non-2xx Response request.
+ *
+ * Builds a syntactically valid request intended for transport-level error tests
+ * (e.g., 400/500). The request itself is correct; only HTTP status differs.
+ */
+export function ac02Non2xxResponse() {
+    // prettier-ignore
+    {
+        const query     = 'status-check';
+        const page      = 1;
+        const perPage   = 10;
+        const sortField = 'date' as const;
+        const sortDir   = 'DESC' as const;
+
+        const payload = {query, page, perPage, sortField, sortDir};
+
+        return payload;
+    }
+}
+
+/**
+ * AC-03 — Malformed JSON request.
+ *
+ * Builds a valid request used in tests where the server responds with
+ * success=true but malformed `data` (e.g., missing items or wrong shapes).
+ */
+export function ac03MalformedJson() {
+    // prettier-ignore
+    {
+        const query     = 'malformed';
+        const page      = 1;
+        const perPage   = 10;
+        const sortField = 'updatedAt' as const;
+        const sortDir   = 'DESC' as const;
+
+        const payload = {query, page, perPage, sortField, sortDir};
+
+        return payload;
+    }
+}
+
+/**
+ * AC-04 — success=false request.
+ *
+ * Builds a valid request used in tests where the API responds with
+ * { success:false } and HTTP status 200 (logical failure branch).
+ */
+export function ac04SuccessFalse() {
+    // prettier-ignore
+    {
+        const query     = 'logical-failure';
+        const page      = 1;
+        const perPage   = 10;
+        const sortField = 'updatedAt' as const;
+        const sortDir   = 'DESC' as const;
+
+        const payload = {query, page, perPage, sortField, sortDir};
+
+        return payload;
+    }
+}

--- a/frontend/tests/helpers/http/responses/entries/GetEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/GetEntryResponseFactory.ts
@@ -1,0 +1,79 @@
+// Purpose: provide consistent mocked API responses for UC-3 GetEntry gateway tests.
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {GetEntryRequest} from '@src/Application/DTO/Entries/GetEntry/GetEntryRequest';
+import type {GetEntryResponse} from '@src/Application/DTO/Entries/GetEntry/GetEntryResponse';
+
+/**
+ * AC-01 — Happy path.
+ *
+ * Builds a mocked GetEntry success response mirroring backend payload:
+ * { success: true, status: 200, data: Entry }.
+ *
+ * @param {GetEntryRequest} request Valid GetEntry request payload.
+ * @returns {GetEntryResponse} Mocked API payload with Entry in `data`.
+ */
+export function ac01HappyPath(request: GetEntryRequest): GetEntryResponse {
+    const item = EntryFactory.make({id: request.id});
+
+    const response: GetEntryResponse = {
+        success: true,
+        status: 200,
+        data: item
+    };
+
+    return response;
+}
+
+/**
+ * AC-03 — Malformed JSON (structural).
+ *
+ * Builds a syntactically valid payload that violates the success=true branch
+ * of UseCaseResponse by omitting the required `data` field.
+ * Used to ensure the gateway rejects such responses as malformed.
+ *
+ * @typedef MalformedGetEntrySuccessPayload
+ * A payload with success=true and missing `data` on purpose.
+ */
+export interface MalformedGetEntrySuccessPayload {
+    success: true;
+    status: number;
+    // intentionally no `data`
+}
+
+/**
+ * @param {GetEntryRequest} _request Accepted for signature consistency; intentionally unused.
+ * @returns {MalformedGetEntrySuccessPayload} success=true payload without `data`.
+ */
+export function ac03MalformedJson(_request: GetEntryRequest): MalformedGetEntrySuccessPayload {
+    void _request;
+
+    const payload: MalformedGetEntrySuccessPayload = {
+        success: true,
+        status: 200
+        // intentionally missing `data`
+    };
+
+    return payload;
+}
+
+/**
+ * AC-04 — success=false with HTTP 200.
+ *
+ * Builds a syntactically valid response where success is false.
+ * Used to assert that the gateway rejects even when status is 200.
+ *
+ * @param {GetEntryRequest} _request Accepted for signature symmetry; intentionally unused.
+ * @returns {GetEntryResponse} Mocked payload with success=false.
+ */
+export function ac04SuccessFalse(_request: GetEntryRequest): GetEntryResponse {
+    void _request;
+
+    // prettier-ignore
+    const payload: GetEntryResponse = {
+        success: false,
+        status : 200,
+        // no data on error responses in our contract
+    };
+
+    return payload;
+}

--- a/frontend/tests/helpers/http/responses/entries/ListEntriesResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/ListEntriesResponseFactory.ts
@@ -1,0 +1,109 @@
+// Purpose: provide consistent mocked API responses for UC-2 ListEntries gateway tests.
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {ListEntriesResponse} from '@src/Application/DTO/Entries/ListEntries/ListEntriesResponse';
+
+/**
+ * AC-01 — Happy Path.
+ *
+ * Builds a mocked ListEntries success response mirroring backend payload:
+ * { success:true, status:200, data:{ items[], page, perPage, total, pagesCount } }.
+ *
+ * @param request Request object with pagination hints (page/perPage optional).
+ * @returns {ListEntriesResponse} Mocked API payload.
+ */
+export function ac01HappyPath(request: {
+    page?: number;
+    perPage?: number;
+}): ListEntriesResponse {
+    // prettier-ignore
+    const page    = typeof request.page === 'number' ? request.page : 1;
+    const perPage = typeof request.perPage === 'number' ? request.perPage : 10;
+
+    const itemA = EntryFactory.make({title: 'Valid title (UC-02, AC-01, #1)'});
+    const itemB = EntryFactory.make({title: 'Valid title (UC-02, AC-01, #2)'});
+    const itemC = EntryFactory.make({title: 'Valid title (UC-02, AC-01, #3)'});
+
+    const items = [itemA, itemB, itemC];
+
+    const total = items.length;
+    const pagesCount = 1;
+
+    const response: ListEntriesResponse = {
+        success: true,
+        status: 200,
+        data: {
+            items,
+            page,
+            perPage,
+            total,
+            pagesCount
+        }
+    };
+
+    return response;
+}
+
+/**
+ * AC-03 — Malformed JSON (structural).
+ *
+ * Builds a syntactically valid payload that violates the success=true branch
+ * by omitting required fields inside `data` (e.g., missing `items`).
+ *
+ * @typedef MalformedListEntriesSuccessPayload
+ * A payload with success=true and malformed/missing `data` internals.
+ */
+export interface MalformedListEntriesSuccessPayload {
+    success: true;
+    status: number;
+    data: {
+        // intentionally missing 'items'
+        page: number;
+        perPage: number;
+        total: number;
+        pagesCount: number;
+    };
+}
+
+/**
+ * @param _request Accepted for signature symmetry; intentionally unused.
+ * @returns {MalformedListEntriesSuccessPayload} success=true payload with malformed data.
+ */
+export function ac03MalformedJson(_request: unknown): MalformedListEntriesSuccessPayload {
+    void _request;
+
+    const payload: MalformedListEntriesSuccessPayload = {
+        success: true,
+        status: 200,
+        data: {
+            // no items: Entry[]
+            page: 1,
+            perPage: 10,
+            total: 3,
+            pagesCount: 1
+        }
+    };
+
+    return payload;
+}
+
+/**
+ * AC-04 — success=false with HTTP 200.
+ *
+ * Builds a syntactically valid response where success is false.
+ * Used to assert that the gateway rejects even when status is 200.
+ *
+ * @param _request Accepted for signature symmetry; intentionally unused.
+ * @returns {ListEntriesResponse} Mocked payload with success=false.
+ */
+export function ac04SuccessFalse(_request: unknown): ListEntriesResponse {
+    void _request;
+
+    // prettier-ignore
+    const payload: ListEntriesResponse = {
+        success: false,
+        status : 200,
+        // no data on error responses in our contract
+    };
+
+    return payload;
+}


### PR DESCRIPTION
Refactor ListEntries & GetEntry to match UC-1: UseCaseResponse<T>, strict transport checks, factory-based tests (AC01–AC04).

Resolves #19