### PR TITLE
refactor(tests): unify base gateway helpers and finalize naming consistency

### DIFF
--- a/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts
@@ -1,8 +1,8 @@
-// frontend/tests/Unit/Entries/AddEntry/Http/AC01_HappyPath.test.ts
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseAddEntryGatewayTest';
 import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/AddEntryRequestFactory';
 import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/AddEntryResponseFactory';
+import {ensureSuccess} from '@tests/helpers/asserts';
 
 /**
  * UC-1: Add Entry (Frontend, Gateway)
@@ -32,23 +32,25 @@ describe('AC01 — AddEntryGateway returns entry (mocked)', () => {
     });
 
     it('returns entry when called with valid payload', async () => {
-        //prettier-ignore
+        // Arrange
+        // prettier-ignore
         const request  = makeRequest();
         const response = makeResponse(request);
 
         // Ensure test factory returned the success-branch payload.
         // This guard narrows the union type AddEntryResponse so that
         // TypeScript recognizes `data` as defined in the success case.
-        if (response.success !== true) {
-            throw new Error('Test setup error: expected success response');
-        }
+        const okResponse = ensureSuccess(response);
 
-        mockJsonOnce(ctx.fetchMock, 200, response);
-        const entry = await ctx.gw.add(request);
+        // Act
+        mockJsonOnce(ctx.fetchMock, 200, okResponse);
+        const entry = await ctx.gateway.add(request);
 
-        expect(entry.title).toBe(response.data.title);
-        expect(entry.body).toBe(response.data.body);
-        expect(entry.date).toBe(response.data.date);
+        // Assert
+        expect(entry.title).toBe(okResponse.data.title);
+        expect(entry.body).toBe(okResponse.data.body);
+        expect(entry.date).toBe(okResponse.data.date);
+
         expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts
@@ -39,13 +39,12 @@ describe('AC02 — AddEntryGateway throws on non-2xx response (generic)', () => 
         const request  = makeRequest();
         const response = makeBadRequest();
 
-        mockJsonOnce(ctx.fetchMock, 400, response);
-
         // Act
-        const fn = ctx.gw.add(request);
-        const message = /400|bad request/i;
+        mockJsonOnce(ctx.fetchMock, 400, response);
+        const fn = ctx.gateway.add(request);
 
         // Assert
+        const message = /400|bad request/i;
         await expect(fn).rejects.toThrowError(message);
     });
 
@@ -55,13 +54,12 @@ describe('AC02 — AddEntryGateway throws on non-2xx response (generic)', () => 
         const request  = makeRequest();
         const response = makeInternalError();
 
-        mockJsonOnce(ctx.fetchMock, 500, response);
-
         // Act
-        const fn = ctx.gw.add(request);
-        const message = /500|internal/i;
+        mockJsonOnce(ctx.fetchMock, 500, response);
+        const fn = ctx.gateway.add(request);
 
         // Assert
+        const message = /500|internal/i;
         await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts
@@ -35,10 +35,9 @@ describe('AC03 — AddEntryGateway throws on malformed JSON', () => {
         const request  = makeRequest();
         const response = makeResponse(request);
 
-        mockJsonOnce(ctx.fetchMock, 200, response);
-
         // Act
-        const fn = ctx.gw.add(request);
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const fn = ctx.gateway.add(request);
 
         // Assert
         const message = 'Malformed response for POST /api/entries';

--- a/frontend/tests/Unit/Entries/AddEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/AC04_SuccessFalse.test.ts
@@ -35,13 +35,12 @@ describe('AC04 — AddEntryGateway throws when success=false (even with 200)', (
         const request  = makeRequest();
         const response = makeResponse(request);
 
-        mockJsonOnce(ctx.fetchMock, 200, response);
-
         // Act
-        const fn = ctx.gw.add(request);
-        const message = 'Malformed response for POST /api/entries';
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const fn = ctx.gateway.add(request);
 
         // Assert
+        const message = 'Malformed response for POST /api/entries';
         await expect(fn).rejects.toThrow(message);
     });
 });

--- a/frontend/tests/Unit/Entries/AddEntry/BaseAddEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/BaseAddEntryGatewayTest.ts
@@ -1,4 +1,8 @@
-import {type HttpTestCtxBase, createHttpCtx} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+import {
+    type HttpTestCtxBase,
+    makeGatewayCtx,
+    mockJsonOnce
+} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
 import {AddEntryGateway} from '@src/Infrastructure/Entries/AddEntryGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
@@ -10,15 +14,9 @@ export type GatewayTestCtx = HttpTestCtxBase & {
  * The caller is responsible for calling ctx.cleanup() in afterEach().
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
-    const base = createHttpCtx(baseUrl);
-    const gw = new AddEntryGateway(base.http);
+    const ctx = makeGatewayCtx(AddEntryGateway, baseUrl);
 
-    const ctx: GatewayTestCtx = {
-        ...base,
-        gw
-    };
-
-    return ctx;
+    return ctx as GatewayTestCtx;
 }
 
-export {mockJsonOnce} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+export {mockJsonOnce};

--- a/frontend/tests/Unit/Entries/AddEntry/BaseAddEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/AddEntry/BaseAddEntryGatewayTest.ts
@@ -6,16 +6,14 @@ import {
 import {AddEntryGateway} from '@src/Infrastructure/Entries/AddEntryGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
-    gw: AddEntryGateway;
+    gateway: AddEntryGateway;
 };
 
 /**
  * Provides a mocked AddEntryGateway built over shared HTTP test context.
- * The caller is responsible for calling ctx.cleanup() in afterEach().
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
     const ctx = makeGatewayCtx(AddEntryGateway, baseUrl);
-
     return ctx as GatewayTestCtx;
 }
 

--- a/frontend/tests/Unit/Entries/BaseEntriesGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/BaseEntriesGatewayTest.ts
@@ -1,4 +1,3 @@
-// BaseHttpGatewayTest.ts — общий базовый хелпер для HTTP-тестов (любой gateway)
 import {vi} from 'vitest';
 import {FetchHttpClient} from '@src/Infrastructure/Http/FetchHttpClient';
 
@@ -24,6 +23,30 @@ export function createHttpCtx(baseUrl: string = 'http://localhost'): HttpTestCtx
     };
 
     const ctx: HttpTestCtxBase = {fetchMock, http, cleanup};
+    return ctx;
+}
+
+/**
+ * Type for a gateway class with constructor that accepts FetchHttpClient.
+ */
+export type HttpGatewayCtor<T> = new (http: FetchHttpClient) => T;
+
+/**
+ * Build a typed gateway test context over the shared HTTP mock context.
+ * Keeps the same outward shape used in per-gateway helpers: { ...HttpTestCtxBase, gw: T }.
+ * Non-breaking for dependent tests that rely on 'gw' property.
+ */
+export function makeGatewayCtx<T>(
+    Gateway: HttpGatewayCtor<T>,
+    baseUrl: string = 'http://localhost'
+): HttpTestCtxBase & {gw: T} {
+    const base = createHttpCtx(baseUrl);
+    const gw = new Gateway(base.http);
+
+    const ctx: HttpTestCtxBase & {gw: T} = {
+        ...base,
+        gw
+    };
 
     return ctx;
 }

--- a/frontend/tests/Unit/Entries/BaseEntriesGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/BaseEntriesGatewayTest.ts
@@ -1,51 +1,50 @@
-import {vi} from 'vitest';
+import {vi, expect} from 'vitest';
 import {FetchHttpClient} from '@src/Infrastructure/Http/FetchHttpClient';
 
 export type HttpTestCtxBase = {
     fetchMock: ReturnType<typeof vi.fn>;
-    http: FetchHttpClient;
+    httpClient: FetchHttpClient;
     cleanup: () => void;
 };
 
 /**
  * Creates a fresh HTTP test context with a stubbed global.fetch and FetchHttpClient.
- * The caller must call ctx.cleanup() in afterEach().
  */
 export function createHttpCtx(baseUrl: string = 'http://localhost'): HttpTestCtxBase {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    const http = new FetchHttpClient(baseUrl);
+    const httpClient = new FetchHttpClient(baseUrl);
 
     const cleanup = (): void => {
         vi.unstubAllGlobals();
         vi.clearAllMocks();
     };
 
-    const ctx: HttpTestCtxBase = {fetchMock, http, cleanup};
-    return ctx;
+    const httpCtx: HttpTestCtxBase = {fetchMock, httpClient, cleanup};
+
+    return httpCtx;
 }
 
 /**
  * Type for a gateway class with constructor that accepts FetchHttpClient.
  */
-export type HttpGatewayCtor<T> = new (http: FetchHttpClient) => T;
+// eslint-disable-next-line no-unused-vars
+type HttpGatewayCtor<T> = new (http: FetchHttpClient) => T;
 
 /**
- * Build a typed gateway test context over the shared HTTP mock context.
- * Keeps the same outward shape used in per-gateway helpers: { ...HttpTestCtxBase, gw: T }.
- * Non-breaking for dependent tests that rely on 'gw' property.
+ * Builds a typed gateway test context over the shared HTTP mock context.
  */
 export function makeGatewayCtx<T>(
     Gateway: HttpGatewayCtor<T>,
     baseUrl: string = 'http://localhost'
-): HttpTestCtxBase & {gw: T} {
-    const base = createHttpCtx(baseUrl);
-    const gw = new Gateway(base.http);
+): HttpTestCtxBase & {gateway: T} {
+    const httpCtx = createHttpCtx(baseUrl);
+    const gateway = new Gateway(httpCtx.httpClient);
 
-    const ctx: HttpTestCtxBase & {gw: T} = {
-        ...base,
-        gw
+    const ctx: HttpTestCtxBase & {gateway: T} = {
+        ...httpCtx,
+        gateway
     };
 
     return ctx;
@@ -67,4 +66,20 @@ export function mockJsonOnce(
     });
 
     fetchMock.mockResolvedValueOnce(res);
+}
+
+/**
+ * Narrows any `{ success: boolean }` union to the success branch.
+ * Uses test assertion so failures are reported by the test runner.
+ *
+ * Example:
+ *   const res = makeResponse(req);
+ *   assertSuccess(res); // from here TS sees res as `{ success: true; ... }`
+ *
+ * @param r The response-like object with a boolean `success` flag
+ */
+export function assertSuccess<T extends {success: boolean}>(
+    r: T
+): asserts r is T & {success: true} {
+    expect(r.success).toBe(true);
 }

--- a/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts
@@ -2,6 +2,7 @@ import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseGetEntryGatewayTest';
 import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/GetEntryRequestFactory';
 import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/GetEntryResponseFactory';
+import {ensureSuccess} from '@tests/helpers/asserts';
 
 /**
  * UC-3: Get Entry (Frontend, Gateway)
@@ -36,16 +37,21 @@ describe('AC01 — GetEntryGateway returns entry (mocked)', () => {
         const request  = makeRequest();
         const response = makeResponse(request);
 
-        mockJsonOnce(ctx.fetchMock, 200, response);
+        // Ensure test factory returned the success-branch payload.
+        // This guard narrows the union type AddEntryResponse so that
+        // TypeScript recognizes `data` as defined in the success case.
+        const okResponse = ensureSuccess(response);
 
         // Act
-        const entry = await ctx.gw.get(request);
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const entry = await ctx.gateway.get(request);
 
         // Assert
         expect(entry.id).toBe(request.id);
-        expect(entry.title).toBe(response.data.title);
-        expect(entry.body).toBe(response.data.body);
-        expect(entry.date).toBe(response.data.date);
+        expect(entry.title).toBe(okResponse.data.title);
+        expect(entry.body).toBe(okResponse.data.body);
+        expect(entry.date).toBe(okResponse.data.date);
+
         expect(entry.createdAt <= entry.updatedAt).toBe(true);
     });
 });

--- a/frontend/tests/Unit/Entries/GetEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC02_Non2xxResponse.test.ts
@@ -41,7 +41,7 @@ describe('AC02 — GetEntryGateway throws on non-2xx response (generic)', () => 
         mockJsonOnce(ctx.fetchMock, 400, response);
 
         // Act
-        const fn = ctx.gw.get(request);
+        const fn = ctx.gateway.get(request);
         const message = /400|bad request/i;
 
         // Assert
@@ -57,7 +57,7 @@ describe('AC02 — GetEntryGateway throws on non-2xx response (generic)', () => 
         mockJsonOnce(ctx.fetchMock, 500, response);
 
         // Act
-        const fn = ctx.gw.get(request);
+        const fn = ctx.gateway.get(request);
         const message = /500|internal/i;
 
         // Assert

--- a/frontend/tests/Unit/Entries/GetEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC03_MalformedJson.test.ts
@@ -39,7 +39,7 @@ describe('AC03 — GetEntryGateway rejects on malformed JSON (missing data)', ()
         mockJsonOnce(ctx.fetchMock, 200, response);
 
         // Act
-        const fn = ctx.gw.get(request);
+        const fn = ctx.gateway.get(request);
         const message = 'Malformed response for GET /api/entries/:id';
 
         // Assert

--- a/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts
@@ -39,7 +39,7 @@ describe('AC04 — GetEntryGateway rejects when success=false with 200 OK', () =
         mockJsonOnce(ctx.fetchMock, 200, response);
 
         // Act
-        const fn = ctx.gw.get(request);
+        const fn = ctx.gateway.get(request);
         const message = 'Malformed response for GET /api/entries/:id';
 
         // Assert

--- a/frontend/tests/Unit/Entries/GetEntry/BaseGetEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/BaseGetEntryGatewayTest.ts
@@ -1,4 +1,8 @@
-import {type HttpTestCtxBase, createHttpCtx} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+import {
+    type HttpTestCtxBase,
+    makeGatewayCtx,
+    mockJsonOnce
+} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
 import {GetEntryGateway} from '@src/Infrastructure/Entries/GetEntryGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
@@ -8,22 +12,11 @@ export type GatewayTestCtx = HttpTestCtxBase & {
 /**
  * Provides a mocked GetEntryGateway built over the shared HTTP test context.
  * The caller is responsible for calling ctx.cleanup() in afterEach().
- *
- * Mechanics:
- * - Reuses the base HTTP mock context (fetchMock, http, cleanup).
- * - Builds a gateway instance over the mocked HttpClient.
- * - Re-exports mock helpers from the common base for consistency.
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
-    const base = createHttpCtx(baseUrl);
-    const gw = new GetEntryGateway(base.http);
+    const ctx = makeGatewayCtx(GetEntryGateway, baseUrl);
 
-    const ctx: GatewayTestCtx = {
-        ...base,
-        gw
-    };
-
-    return ctx;
+    return ctx as GatewayTestCtx;
 }
 
-export {mockJsonOnce} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+export {mockJsonOnce};

--- a/frontend/tests/Unit/Entries/GetEntry/BaseGetEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/GetEntry/BaseGetEntryGatewayTest.ts
@@ -6,16 +6,14 @@ import {
 import {GetEntryGateway} from '@src/Infrastructure/Entries/GetEntryGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
-    gw: GetEntryGateway;
+    gateway: GetEntryGateway;
 };
 
 /**
  * Provides a mocked GetEntryGateway built over the shared HTTP test context.
- * The caller is responsible for calling ctx.cleanup() in afterEach().
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
     const ctx = makeGatewayCtx(GetEntryGateway, baseUrl);
-
     return ctx as GatewayTestCtx;
 }
 

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC01_HappyPath.test.ts
@@ -2,6 +2,7 @@ import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
 import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
 import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/ListEntriesResponseFactory';
+import {ensureSuccess} from '@tests/helpers/asserts';
 
 /**
  * UC-2: List Entries (Frontend, Gateway)
@@ -32,31 +33,38 @@ describe('AC01 — ListEntriesGateway returns items with pagination (mocked)', (
 
     it('returns items[] and pagination fields on success=true', async () => {
         // Arrange
-        const request = makeRequest();
-        const response = makeResponse(request); // success:true, data:{items[], page, perPage, total, pagesCount}
-        mockJsonOnce(ctx.fetchMock, 200, response);
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request);
+
+        // Ensure test factory returned the success-branch payload.
+        // This guard narrows the union type AddEntryResponse so that
+        // TypeScript recognizes `data` as defined in the success case.
+        const okResponse = ensureSuccess(response);
 
         // Act
-        const data = await ctx.gw.list(request);
+        mockJsonOnce(ctx.fetchMock, 200, okResponse);
+        const data = await ctx.gateway.list(request);
 
         // Assert — pagination scalars
-        expect(data.page).toBe(response.data.page);
-        expect(data.perPage).toBe(response.data.perPage);
-        expect(data.total).toBe(response.data.total);
-        expect(data.pagesCount).toBe(response.data.pagesCount);
+        expect(data.page).toBe(okResponse.data.page);
+        expect(data.perPage).toBe(okResponse.data.perPage);
+        expect(data.total).toBe(okResponse.data.total);
+        expect(data.pagesCount).toBe(okResponse.data.pagesCount);
 
         // Assert — items[]
         expect(Array.isArray(data.items)).toBe(true);
-        expect(data.items.length).toBe(response.data.items.length);
+        expect(data.items.length).toBe(okResponse.data.items.length);
 
         if (data.items.length > 0) {
             const first = data.items[0];
-            const firstRef = response.data.items[0];
+            const firstRef = okResponse.data.items[0];
 
             expect(first.id).toBe(firstRef.id);
             expect(first.title).toBe(firstRef.title);
             expect(first.body).toBe(firstRef.body);
             expect(first.date).toBe(firstRef.date);
+
             expect(first.createdAt <= first.updatedAt).toBe(true);
         }
     });

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC02_Non2xxResponse.test.ts
@@ -1,7 +1,10 @@
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseListEntriesGatewayTest';
 import {ac02Non2xxResponse as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
-import {makeBadRequest, makeInternalError} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
+import {
+    makeBadRequest,
+    makeInternalError
+} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
 
 /**
  * UC-2: List Entries (Frontend, Gateway)
@@ -35,7 +38,7 @@ describe('AC02 — ListEntriesGateway throws on non-2xx response (generic)', () 
 
         mockJsonOnce(ctx.fetchMock, 400, response);
 
-        const fn = ctx.gw.list(request);
+        const fn = ctx.gateway.list(request);
         const message = /400|bad request/i;
 
         await expect(fn).rejects.toThrowError(message);
@@ -47,7 +50,7 @@ describe('AC02 — ListEntriesGateway throws on non-2xx response (generic)', () 
 
         mockJsonOnce(ctx.fetchMock, 500, response);
 
-        const fn = ctx.gw.list(request);
+        const fn = ctx.gateway.list(request);
         const message = /500|internal/i;
 
         await expect(fn).rejects.toThrowError(message);

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC03_MalformedJson.test.ts
@@ -37,7 +37,7 @@ describe('AC03 — ListEntriesGateway rejects on malformed JSON (missing items)'
 
         mockJsonOnce(ctx.fetchMock, 200, response);
 
-        const fn = ctx.gw.list(request);
+        const fn = ctx.gateway.list(request);
         const message = 'Malformed response for GET /api/entries';
 
         await expect(fn).rejects.toThrowError(message);

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/AC04_SuccessFalse.test.ts
@@ -37,7 +37,7 @@ describe('AC04 — ListEntriesGateway rejects when success=false with 200 OK', (
 
         mockJsonOnce(ctx.fetchMock, 200, response);
 
-        const fn = ctx.gw.list(request);
+        const fn = ctx.gateway.list(request);
         const message = 'Malformed response for GET /api/entries';
 
         await expect(fn).rejects.toThrowError(message);

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/BaseListEntriesGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/BaseListEntriesGatewayTest.ts
@@ -6,16 +6,14 @@ import {
 import {ListEntriesGateway} from '@src/Infrastructure/Entries/ListEntriesGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
-    gw: ListEntriesGateway;
+    gateway: ListEntriesGateway;
 };
 
 /**
  * Provides a mocked ListEntriesGateway built over the shared HTTP test context.
- * The caller must call ctx.cleanup() in afterEach().
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
     const ctx = makeGatewayCtx(ListEntriesGateway, baseUrl);
-
     return ctx as GatewayTestCtx;
 }
 

--- a/frontend/tests/Unit/Entries/ListEntriesGateway/BaseListEntriesGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/ListEntriesGateway/BaseListEntriesGatewayTest.ts
@@ -1,4 +1,8 @@
-import {type HttpTestCtxBase, createHttpCtx} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+import {
+    type HttpTestCtxBase,
+    makeGatewayCtx,
+    mockJsonOnce
+} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
 import {ListEntriesGateway} from '@src/Infrastructure/Entries/ListEntriesGateway';
 
 export type GatewayTestCtx = HttpTestCtxBase & {
@@ -8,22 +12,11 @@ export type GatewayTestCtx = HttpTestCtxBase & {
 /**
  * Provides a mocked ListEntriesGateway built over the shared HTTP test context.
  * The caller must call ctx.cleanup() in afterEach().
- *
- * Mechanics:
- * - Reuses the base HTTP mock context (fetchMock, http, cleanup).
- * - Builds a gateway instance over the mocked HttpClient.
- * - Re-exports mock helpers for consistency across gateway suites.
  */
 export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
-    const base = createHttpCtx(baseUrl);
-    const gw = new ListEntriesGateway(base.http);
+    const ctx = makeGatewayCtx(ListEntriesGateway, baseUrl);
 
-    const ctx: GatewayTestCtx = {
-        ...base,
-        gw
-    };
-
-    return ctx;
+    return ctx as GatewayTestCtx;
 }
 
-export {mockJsonOnce} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+export {mockJsonOnce};

--- a/frontend/tests/helpers/asserts.ts
+++ b/frontend/tests/helpers/asserts.ts
@@ -1,0 +1,15 @@
+import {expect} from 'vitest';
+
+/**
+ * Ensures the response is the success branch and returns the same object
+ * with a narrowed type, so `response.data` is safely available.
+ *
+ * If not success, the test fails via expect(...).
+ */
+export function ensureSuccess<T extends {success: boolean}>(r: T): T & {success: true} {
+    expect(r.success).toBe(true);
+
+    const ok = r as T & {success: true};
+
+    return ok;
+}

--- a/frontend/tests/helpers/http/responses/entries/ListEntriesResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/ListEntriesResponseFactory.ts
@@ -11,10 +11,7 @@ import type {ListEntriesResponse} from '@src/Application/DTO/Entries/ListEntries
  * @param request Request object with pagination hints (page/perPage optional).
  * @returns {ListEntriesResponse} Mocked API payload.
  */
-export function ac01HappyPath(request: {
-    page?: number;
-    perPage?: number;
-}): ListEntriesResponse {
+export function ac01HappyPath(request: {page?: number; perPage?: number}): ListEntriesResponse {
     // prettier-ignore
     const page    = typeof request.page === 'number' ? request.page : 1;
     const perPage = typeof request.perPage === 'number' ? request.perPage : 10;


### PR DESCRIPTION
Unifies base gateway test helpers by introducing a shared `makeGatewayCtx()` factory, standardizes variable names (`httpClient`, `gateway`, `httpCtx`), and adds a clear `ensureSuccess()` helper for success-branch narrowing in tests. Removes legacy `gw` references and redundant code.

Resolves #25