### PR TITLE
docs(api): add Entries API contract and complete frontend acceptance coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,9 +25,19 @@ Start here to navigate the project documentation.
 The frontend (TypeScript + Vite + Vitest) has its own tooling and workflow.  
 See [`frontend/README.md`](./frontend/README.md) for details.
 
+### API Documentation
+
+- **Entries API Contract (UC-1 → UC-5)**  
+  Defines all response shapes and statuses used by frontend gateways.  
+  → [`frontend/docs/api/entries-api-contract.md`](frontend/docs/api/entries-api-contract.md)
+
 ## Frontend Acceptance
 
-- UC-2 details: [UC-2 — List Entries (Frontend AC)](frontend/acceptance/UC-2-ListEntries.md)
+- UC-1 details: [UC-1 — Add Entry (Frontend AC)](frontend/acceptance/UC-1-AddEntry.md);
+- UC-2 details: [UC-2 — List Entries (Frontend AC)](frontend/acceptance/UC-2-ListEntries.md);
+- UC-3 details: [UC-3 — Get Entry (Frontend AC)](frontend/acceptance/UC-3-GetEntry.md);
+- UC-4 details: [UC-4 — Delete Entry (Frontend AC)](frontend/acceptance/UC-4-DeleteEntry.md);
+- UC-5 details: [UC-5 — Update Entry (Frontend AC)](frontend/acceptance/UC-5-UpdateEntry.md).
 
 
 ## Process & Conventions

--- a/docs/api/entries-api-contract.md
+++ b/docs/api/entries-api-contract.md
@@ -1,0 +1,292 @@
+# Entries API Contract — Derived from Functional Test Log
+
+> **Scope:** UC‑1 AddEntry, UC‑2 ListEntries, UC‑3 GetEntry, UC‑4 DeleteEntry, UC‑5 UpdateEntry  
+
+---
+
+## 0. Envelope (observed)
+
+Every endpoint returns JSON with these fields observed in the log:
+
+- `success: boolean`
+- `status: number`
+- `data: object` (present **only when** `success=true`)
+- `code: string` (present **only when** `success=false`)
+
+---
+
+## 1) UC‑1 — AddEntry
+
+### Success — 200
+```json
+{
+  "success": true,
+  "data": {
+    "id": "829ad7de-147d-4f6d-bb6b-f8be26aa4108",
+    "title": "Valid title",
+    "body": "Valid body",
+    "date": "2025-02-12",
+    "createdAt": "2025-10-09T13:01:57+00:00",
+    "updatedAt": "2025-10-09T13:01:57+00:00"
+  },
+  "status": 200
+}
+```
+
+### Missing/required fields — 400
+Representative cases (each returns one `code`):
+
+- `TITLE_REQUIRED`
+- `BODY_REQUIRED`
+- `DATE_REQUIRED`
+
+Example:
+```json
+{
+  "success": false,
+  "status": 400,
+  "code": "TITLE_REQUIRED"
+}
+```
+
+### Validation errors — 422
+Representative cases:
+
+- `TITLE_TOO_LONG`
+- `BODY_TOO_LONG`
+- `DATE_INVALID`
+- `TITLE_REQUIRED` (when empty/whitespace after normalization)
+
+Example:
+```json
+{
+  "success": false,
+  "status": 422,
+  "code": "TITLE_REQUIRED"
+}
+```
+
+---
+
+## 3) UC‑2 — ListEntries
+
+### Success — 200
+The response contains `items[]` and pagination fields.
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "id": "426cce2d-59c8-4858-abe8-4f4f2256ef44",
+        "title": "Valid title",
+        "body": "Valid body",
+        "date": "2025-02-14",
+        "createdAt": "2025-02-12T10:00:02+00:00",
+        "updatedAt": "2025-02-12T10:00:02+00:00"
+      },
+      {
+        "id": "7588ed92-45a6-4298-8117-67b93257375e",
+        "title": "Valid title",
+        "body": "Valid body",
+        "date": "2025-02-13",
+        "createdAt": "2025-02-12T10:00:01+00:00",
+        "updatedAt": "2025-02-12T10:00:01+00:00"
+      },
+      {
+        "id": "ecdf598b-eec4-44c1-b2a2-226938270e6e",
+        "title": "Valid title",
+        "body": "Valid body",
+        "date": "2025-02-12",
+        "createdAt": "2025-02-12T10:00:00+00:00",
+        "updatedAt": "2025-02-12T10:00:00+00:00"
+      }
+    ],
+    "page": 1,
+    "perPage": 10,
+    "total": 3,
+    "pagesCount": 1
+  },
+  "status": 200
+}
+```
+
+### Empty page — 200
+```json
+{
+  "success": true,
+  "data": {
+    "items": [],
+    "page": 10,
+    "perPage": 2,
+    "total": 5,
+    "pagesCount": 3
+  },
+  "status": 200
+}
+```
+
+### Validation errors — 422
+Representative cases:
+
+- `DATE_INVALID`
+- `DATE_RANGE_INVALID`
+- `QUERY_TOO_LONG`
+
+Example:
+```json
+{
+  "success": false,
+  "status": 422,
+  "code": "DATE_INVALID"
+}
+```
+
+### Type/shape errors — 400
+Representative cases (parameters sent as arrays or wrong primitive type):
+
+- `PAGE_MUST_BE_NUMERIC`
+- `PER_PAGE_MUST_BE_NUMERIC`
+- `SORT_FIELD_MUST_BE_STRING`
+- `DIRECTION_MUST_BE_STRING`
+- `DATE_FROM_MUST_BE_STRING`
+- `DATE_TO_MUST_BE_STRING`
+- `DATE_MUST_BE_STRING`
+- `QUERY_MUST_BE_STRING`
+
+Example:
+```json
+{
+  "success": false,
+  "status": 400,
+  "code": "PAGE_MUST_BE_NUMERIC"
+}
+```
+
+---
+
+## 3) UC‑3 — GetEntry
+
+### Success — 200
+```json
+{
+  "success": true,
+  "data": {
+    "id": "3d85af08-dfa5-48b3-bf04-b519852c72a2",
+    "title": "Valid title",
+    "body": "Valid body",
+    "date": "2025-02-12",
+    "createdAt": "2025-10-09T12:01:57+00:00",
+    "updatedAt": "2025-10-09T12:01:57+00:00"
+  },
+  "status": 200
+}
+```
+
+### Not found — 404
+```json
+{
+  "success": false,
+  "status": 404,
+  "code": "ENTRY_NOT_FOUND"
+}
+```
+
+### Invalid id — 422
+```json
+{
+  "success": false,
+  "status": 422,
+  "code": "ID_INVALID"
+}
+```
+
+---
+
+## 4) UC‑4 — DeleteEntry
+
+### Success — 200
+Returns the deleted entry **object** in `data`:
+```json
+{
+  "success": true,
+  "data": {
+    "id": "d914fa57-db05-47e0-92ee-9f56386ccda5",
+    "title": "Valid title",
+    "body": "Valid body",
+    "date": "2025-02-12",
+    "createdAt": "2025-10-09T12:01:57+00:00",
+    "updatedAt": "2025-10-09T12:01:57+00:00"
+  },
+  "status": 200
+}
+```
+
+### Not found — 404
+```json
+{
+  "success": false,
+  "status": 404,
+  "code": "ENTRY_NOT_FOUND"
+}
+```
+
+### Invalid id — 422
+```json
+{
+  "success": false,
+  "status": 422,
+  "code": "ID_INVALID"
+}
+```
+
+---
+
+## 5) UC‑5 — UpdateEntry
+
+### Success — 200
+```json
+{
+  "success": true,
+  "data": {
+    "id": "230cd464-2c3b-422e-bff0-705657ba72c4",
+    "title": "Updated title",
+    "body": "Valid body",
+    "date": "2025-02-12",
+    "createdAt": "2025-10-09T12:01:59+00:00",
+    "updatedAt": "2025-10-09T13:02:00+00:00"
+  },
+  "status": 200
+}
+```
+
+### Validation / business errors — 422
+Representative cases:
+
+- `ID_INVALID`
+- `TITLE_REQUIRED`
+- `TITLE_TOO_LONG`
+- `BODY_REQUIRED`
+- `BODY_TOO_LONG`
+- `DATE_INVALID`
+- `NO_FIELDS_TO_UPDATE`
+- `NO_CHANGES_APPLIED`
+
+Example:
+```json
+{
+  "success": false,
+  "status": 422,
+  "code": "NO_FIELDS_TO_UPDATE"
+}
+```
+
+### Not found — 404
+```json
+{
+  "success": false,
+  "status": 404,
+  "code": "ENTRY_NOT_FOUND"
+}
+```

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -46,6 +46,9 @@ Daylog frontend uses a modern TypeScript-based toolchain for consistent code qua
    npm test
    ```
 
+### API Contracts
+- [Entries API Contract](docs/api/entries-api-contract.md) — based on backend functional tests (UC-1…UC-5, 2025-10-09)
+
 ## Notes
 
 - `.editorconfig` ensures uniform indentation (4 spaces) and LF line endings.  

--- a/docs/frontend/acceptance/UC-1-AddEntry.md
+++ b/docs/frontend/acceptance/UC-1-AddEntry.md
@@ -1,0 +1,32 @@
+# UC-1 — Add Entry (Frontend AC)
+
+## Scope
+Frontend gateway validates only the parts of the API response it consumes.  
+Authoritative sources:
+- **HTTP status** (`res.ok` from Fetch)
+- **success: boolean**
+- **data: Entry** (single object)
+
+Ignored by frontend:
+- The `status` field inside JSON
+- Any diagnostics fields not used by UI
+
+## Acceptance Criteria
+
+- **AC-01 Happy Path**  
+  200 OK, `success=true`, `typeof data === 'object'` ⇒ returns `Entry`.
+
+- **AC-02 Non-2xx**  
+  `res.ok=false` (e.g., 400/500) ⇒ throws `Error("HTTP {status} ...")`.
+
+- **AC-03 Malformed JSON**  
+  Missing or non-object `data` ⇒ throws `Error("Malformed response")`.
+
+- **AC-04 Success=false**  
+  200 OK but `success=false` ⇒ throws `Error("Malformed response: success")`.
+
+## Coverage
+- `frontend/tests/Unit/Entries/AddEntry/AC01_HappyPath.test.ts`;
+- `frontend/tests/Unit/Entries/AddEntry/AC02_Non2xxResponse.test.ts`;
+- `frontend/tests/Unit/Entries/AddEntry/AC03_MalformedJson.test.ts`;
+- `frontend/tests/Unit/Entries/AddEntry/AC04_SuccessFalse.test.ts`.

--- a/docs/frontend/acceptance/UC-2-ListEntries.md
+++ b/docs/frontend/acceptance/UC-2-ListEntries.md
@@ -26,7 +26,7 @@ Ignored by frontend:
   200 OK but `success=false` ⇒ throws `Error("Malformed response: success")`.
 
 ## Coverage
-- `frontend/tests/Unit/Entries/HttpEntriesGateway/AC01_HappyPath.test.ts`  
-- `frontend/tests/Unit/Entries/HttpEntriesGateway/AC02_Non2xxResponse.test.ts`  
-- `frontend/tests/Unit/Entries/HttpEntriesGateway/AC03_MalformedJson.test.ts`  
-- `frontend/tests/Unit/Entries/HttpEntriesGateway/AC04_SuccessFalse.test.ts`
+- `frontend/tests/Unit/Entries/ListEntries/AC01_HappyPath.test.ts`;
+- `frontend/tests/Unit/Entries/ListEntries/AC02_Non2xxResponse.test.ts`;
+- `frontend/tests/Unit/Entries/ListEntries/AC03_MalformedJson.test.ts`;
+- `frontend/tests/Unit/Entries/ListEntries/AC04_SuccessFalse.test.ts`.

--- a/docs/frontend/acceptance/UC-3-GetEntry.md
+++ b/docs/frontend/acceptance/UC-3-GetEntry.md
@@ -1,0 +1,32 @@
+# UC-3 — Get Entry (Frontend AC)
+
+## Scope
+Frontend gateway validates only the parts of the API response it consumes.  
+Authoritative sources:
+- **HTTP status** (`res.ok` from Fetch)
+- **success: boolean**
+- **data: Entry** (single object)
+
+Ignored by frontend:
+- The `status` field inside JSON
+- Any diagnostics fields not used by UI
+
+## Acceptance Criteria
+
+- **AC-01 Happy Path**  
+  200 OK, `success=true`, `typeof data === 'object'` ⇒ returns `Entry`.
+
+- **AC-02 Non-2xx**  
+  `res.ok=false` (e.g., 400/500) ⇒ throws `Error("HTTP {status} ...")`.
+
+- **AC-03 Malformed JSON**  
+  Missing or non-object `data` ⇒ throws `Error("Malformed response")`.
+
+- **AC-04 Success=false**  
+  200 OK but `success=false` ⇒ throws `Error("Malformed response: success")`.
+
+## Coverage
+- `frontend/tests/Unit/Entries/GetEntry/AC01_HappyPath.test.ts`;
+- `frontend/tests/Unit/Entries/GetEntry/AC02_Non2xxResponse.test.ts`;
+- `frontend/tests/Unit/Entries/GetEntry/AC03_MalformedJson.test.ts`;
+- `frontend/tests/Unit/Entries/GetEntry/AC04_SuccessFalse.test.ts`.

--- a/docs/frontend/acceptance/UC-4-DeleteEntry.md
+++ b/docs/frontend/acceptance/UC-4-DeleteEntry.md
@@ -1,0 +1,32 @@
+# UC-4 — Delete Entry (Frontend AC)
+
+## Scope
+Frontend gateway validates only the parts of the API response it consumes.  
+Authoritative sources:
+- **HTTP status** (`res.ok` from Fetch)
+- **success: boolean**
+- **data: Entry** (deleted entry object)
+
+Ignored by frontend:
+- The `status` field inside JSON
+- Any diagnostics fields not used by UI
+
+## Acceptance Criteria
+
+- **AC-01 Happy Path**  
+  200 OK, `success=true`, `typeof data === 'object'` ⇒ returns deleted `Entry`.
+
+- **AC-02 Non-2xx**  
+  `res.ok=false` (e.g., 404/500) ⇒ throws `Error("HTTP {status} ...")`.
+
+- **AC-03 Malformed JSON**  
+  Missing or non-object `data` ⇒ throws `Error("Malformed response")`.
+
+- **AC-04 Success=false**  
+  200 OK but `success=false` ⇒ throws `Error("Malformed response: success")`.
+
+## Coverage
+- `frontend/tests/Unit/Entries/DeleteEntry/AC01_HappyPath.test.ts`;
+- `frontend/tests/Unit/Entries/DeleteEntry/AC02_Non2xxResponse.test.ts`;
+- `frontend/tests/Unit/Entries/DeleteEntry/AC03_MalformedJson.test.ts`;
+- `frontend/tests/Unit/Entries/DeleteEntry/AC04_SuccessFalse.test.ts`.

--- a/docs/frontend/acceptance/UC-5-UpdateEntry.md
+++ b/docs/frontend/acceptance/UC-5-UpdateEntry.md
@@ -1,0 +1,32 @@
+# UC-5 — Update Entry (Frontend AC)
+
+## Scope
+Frontend gateway validates only the parts of the API response it consumes.  
+Authoritative sources:
+- **HTTP status** (`res.ok` from Fetch)
+- **success: boolean**
+- **data: Entry** (updated entry object)
+
+Ignored by frontend:
+- The `status` field inside JSON
+- Any diagnostics fields not used by UI
+
+## Acceptance Criteria
+
+- **AC-01 Happy Path**  
+  200 OK, `success=true`, `typeof data === 'object'` ⇒ returns updated `Entry`.
+
+- **AC-02 Non-2xx**  
+  `res.ok=false` (e.g., 404/500) ⇒ throws `Error("HTTP {status} ...")`.
+
+- **AC-03 Malformed JSON**  
+  Missing or non-object `data` ⇒ throws `Error("Malformed response")`.
+
+- **AC-04 Success=false**  
+  200 OK but `success=false` ⇒ throws `Error("Malformed response: success")`.
+
+## Coverage
+- `frontend/tests/Unit/Entries/UpdateEntry/AC01_HappyPath.test.ts`;
+- `frontend/tests/Unit/Entries/UpdateEntry/AC02_Non2xxResponse.test.ts`;
+- `frontend/tests/Unit/Entries/UpdateEntry/AC03_MalformedJson.test.ts`;
+- `frontend/tests/Unit/Entries/UpdateEntry/AC04_SuccessFalse.test.ts`.


### PR DESCRIPTION
### Summary
Adds documentation for Entries API contracts and completes frontend acceptance criteria coverage.

### Purpose
Creates a unified, versioned documentation layer between backend functional tests and frontend gateway validation.
Establishes clear acceptance boundaries for all use cases in the Entries module.

Resolves #27 