### PR TITLE
feat(frontend): UC-4 DeleteEntry — gateway, DTOs and tests

### DIFF
--- a/frontend/src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest.ts
+++ b/frontend/src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest.ts
@@ -1,0 +1,13 @@
+/**
+ * UC-4: Delete Entry — request DTO.
+ *
+ * Describes the path parameter required by DELETE /api/entries/:id.
+ * The gateway will serialize this DTO by substituting {id} into the URL.
+ */
+export type DeleteEntryRequest = {
+    /**
+     * Entry identifier (UUID v4 as produced by backend).
+     * Validation of format/semantics is out of scope for the gateway DTO.
+     */
+    id: string;
+};

--- a/frontend/src/Application/DTO/Entries/DeleteEntry/DeleteEntryResponse.ts
+++ b/frontend/src/Application/DTO/Entries/DeleteEntry/DeleteEntryResponse.ts
@@ -1,0 +1,12 @@
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+
+/**
+ * UC-4: Delete Entry — response DTO.
+ *
+ * Mirrors backend payload exactly:
+ * { success: true, status: 200, data: Entry }.
+ *
+ * Errors are returned with non-2xx HTTP status (e.g., 404/422) and success:false.
+ */
+export type DeleteEntryResponse = UseCaseResponse<Entry>;

--- a/frontend/src/Infrastructure/Entries/DeleteEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/DeleteEntryGateway.ts
@@ -1,13 +1,15 @@
 import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
 import type {Entry} from '@src/Domain/Entries/Entry';
 import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
-import type {DeleteEntryResponse} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryResponse';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 
 /**
  * UC-4: Delete Entry (Frontend)
  *
- * Sends DELETE /api/entries/:id and returns response.data as Entry.
- * Minimal GREEN for AC-01: no extra transport/malformed checks yet.
+ * Sends DELETE /api/entries/:id and validates transport envelope:
+ * - success must be true;
+ * - data must be a non-null object.
+ * Otherwise throws an Error with a descriptive message.
  */
 export class DeleteEntryGateway {
     private readonly http: HttpClient;
@@ -18,10 +20,22 @@ export class DeleteEntryGateway {
 
     async delete(req: DeleteEntryRequest): Promise<Entry> {
         const url = `/api/entries/${req.id}`;
+        const json = await this.http.request<UseCaseResponse<Entry>>('DELETE', url);
 
-        const json = await this.http.request<DeleteEntryResponse>('DELETE', url);
-        const result = json.data;
+        // success flag must be true
+        if (json.success !== true) {
+            const message = 'Malformed response for DELETE /api/entries/:id';
+            throw new Error(message);
+        }
 
-        return result;
+        // data must be a non-null object
+        const hasData = typeof json.data === 'object' && json.data !== null;
+        if (!hasData) {
+            const message = 'Malformed response for DELETE /api/entries/:id';
+            throw new Error(message);
+        }
+
+        const entry = json.data as Entry;
+        return entry;
     }
 }

--- a/frontend/src/Infrastructure/Entries/DeleteEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/DeleteEntryGateway.ts
@@ -1,0 +1,24 @@
+import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
+
+/**
+ * UC-4: Delete Entry (Frontend)
+ *
+ * Sends DELETE /api/entries/:id.
+ * This is a RED-phase stub: not implemented yet.
+ */
+export class DeleteEntryGateway {
+    private readonly http: HttpClient;
+
+    constructor(http: HttpClient) {
+        this.http = http;
+    }
+
+    async delete(_req: DeleteEntryRequest): Promise<Entry> {
+        void _req;
+
+        const message = 'DeleteEntryGateway.delete: not implemented (RED)';
+        throw new Error(message);
+    }
+}

--- a/frontend/src/Infrastructure/Entries/DeleteEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/DeleteEntryGateway.ts
@@ -1,12 +1,13 @@
 import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
 import type {Entry} from '@src/Domain/Entries/Entry';
 import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
+import type {DeleteEntryResponse} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryResponse';
 
 /**
  * UC-4: Delete Entry (Frontend)
  *
- * Sends DELETE /api/entries/:id.
- * This is a RED-phase stub: not implemented yet.
+ * Sends DELETE /api/entries/:id and returns response.data as Entry.
+ * Minimal GREEN for AC-01: no extra transport/malformed checks yet.
  */
 export class DeleteEntryGateway {
     private readonly http: HttpClient;
@@ -15,10 +16,12 @@ export class DeleteEntryGateway {
         this.http = http;
     }
 
-    async delete(_req: DeleteEntryRequest): Promise<Entry> {
-        void _req;
+    async delete(req: DeleteEntryRequest): Promise<Entry> {
+        const url = `/api/entries/${req.id}`;
 
-        const message = 'DeleteEntryGateway.delete: not implemented (RED)';
-        throw new Error(message);
+        const json = await this.http.request<DeleteEntryResponse>('DELETE', url);
+        const result = json.data;
+
+        return result;
     }
 }

--- a/frontend/tests/Unit/Entries/DeleteEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/DeleteEntry/AC01_HappyPath.test.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseDeleteEntryGatewayTest';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/DeleteEntryRequestFactory';
+import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/DeleteEntryResponseFactory';
+import {ensureSuccess} from '@tests/helpers/asserts';
+
+/**
+ * UC-4: Delete Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that DeleteEntryGateway resolves with Entry when API responds
+ * 200 + { success: true, data: Entry }.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals).
+ * - Build a matching success response via response factory from the same request.
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Call gateway.delete(request) and assert returned Entry matches response.data.
+ *
+ * Cases covered:
+ * - AC-01 — Happy path with well-formed JSON and success=true.
+ */
+describe('AC01 — DeleteEntryGateway returns Entry (mocked)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('returns Entry when called with valid id', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request);
+
+        // Narrow union to the success branch for safe access to data.*
+        const ok = ensureSuccess(response);
+
+        // Act
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const entry = await ctx.gateway.delete(request);
+
+        // Assert
+        expect(entry.id).toBe(request.id);
+        expect(entry.title).toBe(ok.data.title);
+        expect(entry.body).toBe(ok.data.body);
+        expect(entry.date).toBe(ok.data.date);
+
+        // createdAt must be <= updatedAt
+        expect(entry.createdAt <= entry.updatedAt).toBe(true);
+    });
+});

--- a/frontend/tests/Unit/Entries/DeleteEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/DeleteEntry/AC02_Non2xxResponse.test.ts
@@ -1,0 +1,66 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseDeleteEntryGatewayTest';
+import {ac02Non2xxResponse as makeRequest} from '@tests/helpers/http/requests/entries/DeleteEntryRequestFactory';
+import {
+    makeBadRequest,
+    makeInternalError
+} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
+
+/**
+ * UC-4: Delete Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that DeleteEntryGateway rejects on generic non-2xx HTTP responses.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals).
+ * - Use common non-2xx response factories (no domain codes asserted here).
+ * - Mock fetch with 400/500 and assert rejection.
+ *
+ * Cases:
+ * - AC-02a — 400 Bad Request → rejects.
+ * - AC-02b — 500 Internal Server Error → rejects.
+ */
+describe('AC02 — DeleteEntryGateway throws on non-2xx response (generic)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when API responds with 400 Bad Request', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeBadRequest();
+
+        mockJsonOnce(ctx.fetchMock, 400, response);
+
+        // Act
+        const fn = ctx.gateway.delete(request);
+        const message = /400|bad request/i;
+
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
+    });
+
+    it('throws when API responds with 500 Internal Server Error', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeInternalError();
+
+        mockJsonOnce(ctx.fetchMock, 500, response);
+
+        // Act
+        const fn = ctx.gateway.delete(request);
+        const message = /500|internal/i;
+
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/DeleteEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/DeleteEntry/AC03_MalformedJson.test.ts
@@ -1,0 +1,48 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseDeleteEntryGatewayTest';
+import {ac03MalformedJson as makeRequest} from '@tests/helpers/http/requests/entries/DeleteEntryRequestFactory';
+import {ac03MalformedJson as makeResponse} from '@tests/helpers/http/responses/entries/DeleteEntryResponseFactory';
+
+/**
+ * UC-4: Delete Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that DeleteEntryGateway rejects when API responds with a malformed JSON body,
+ * i.e. success=true but missing required `data` property.
+ *
+ * Mechanics:
+ * - Build a valid request via request factory (no literals at the call site).
+ * - Build a malformed success response via response factory (no `data`).
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert the gateway rejects with a Malformed* style error.
+ *
+ * Cases covered:
+ * - AC-03 — Malformed JSON (success=true without `data`).
+ */
+describe('AC03 — DeleteEntryGateway rejects on malformed JSON (missing data)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when success=true but `data` is missing', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:true, no data
+
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        // Act
+        const fn = ctx.gateway.delete(request);
+        const message = 'Malformed response for DELETE /api/entries/:id';
+
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/DeleteEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/DeleteEntry/AC04_SuccessFalse.test.ts
@@ -1,0 +1,48 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseDeleteEntryGatewayTest';
+import {ac04SuccessFalse as makeRequest} from '@tests/helpers/http/requests/entries/DeleteEntryRequestFactory';
+import {ac04SuccessFalse as makeResponse} from '@tests/helpers/http/responses/entries/DeleteEntryResponseFactory';
+
+/**
+ * UC-4: Delete Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Contract guard: reject when API responds with { success:false } while HTTP status is 200.
+ * Backend should not send logical failures with 200; if it happens, gateway must treat it as malformed.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Build a mocked response with success=false via response factory.
+ * - Mock HTTP once with status 200 and the error-like payload.
+ * - Assert that the gateway rejects with a descriptive error.
+ *
+ * Cases covered:
+ * - AC-04 — Contract guard: success=false with 200 → reject as malformed.
+ */
+describe('AC04 — DeleteEntryGateway rejects when success=false with 200 OK (contract guard)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when API responds with success=false despite 200 status', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:false, 200
+
+        mockJsonOnce(ctx.fetchMock, 200, response);
+
+        // Act
+        const fn = ctx.gateway.delete(request);
+        const message = 'Malformed response for DELETE /api/entries/:id';
+
+        // Assert
+        await expect(fn).rejects.toThrowError(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/DeleteEntry/BaseDeleteEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/DeleteEntry/BaseDeleteEntryGatewayTest.ts
@@ -1,0 +1,20 @@
+import {
+    type HttpTestCtxBase,
+    makeGatewayCtx,
+    mockJsonOnce
+} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+import {DeleteEntryGateway} from '@src/Infrastructure/Entries/DeleteEntryGateway';
+
+export type GatewayTestCtx = HttpTestCtxBase & {
+    gateway: DeleteEntryGateway;
+};
+
+/**
+ * Provides a mocked DeleteEntryGateway built over the shared HTTP test context.
+ */
+export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
+    const ctx = makeGatewayCtx(DeleteEntryGateway, baseUrl);
+    return ctx as GatewayTestCtx;
+}
+
+export {mockJsonOnce};

--- a/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
@@ -19,3 +19,13 @@ export function ac02Non2xxResponse(): DeleteEntryRequest {
         id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
     };
 }
+
+/**
+ * AC-03 — Malformed JSON (success:true but no data)
+ * Uses a stable UUID; value irrelevant for this test.
+ */
+export function ac03MalformedJson(): DeleteEntryRequest {
+    return {
+        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    };
+}

--- a/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
@@ -1,0 +1,12 @@
+import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
+import {uuidv4} from '@tests/helpers/utils/uuid';
+
+/**
+ * Request factory for UC-4 DeleteEntry.
+ * AC-01 builds a valid payload with a stable UUID (no literals at call sites).
+ */
+export function ac01HappyPath(): DeleteEntryRequest {
+    return {
+        id: uuidv4()
+    };
+}

--- a/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
@@ -29,3 +29,13 @@ export function ac03MalformedJson(): DeleteEntryRequest {
         id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
     };
 }
+
+/**
+ * AC-04 — Contract guard (success:false with 200).
+ * Uses a stable UUID; concrete value is irrelevant for this check.
+ */
+export function ac04SuccessFalse(): DeleteEntryRequest {
+    return {
+        id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    };
+}

--- a/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
@@ -1,41 +1,76 @@
+// UC-4 DeleteEntry — Request factory (AC01–AC04).
 import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
-import {uuidv4} from '@tests/helpers/utils/uuid';
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
- * Request factory for UC-4 DeleteEntry.
- * AC-01 builds a valid payload with a stable UUID (no literals at call sites).
+ * AC-01 — Happy Path request.
+ *
+ * Builds a request object with a valid UUID taken from EntryFactory.
+ * This mirrors real-world usage where the client already knows the entry ID.
+ *
+ * @returns {DeleteEntryRequest} Valid request for happy path.
  */
 export function ac01HappyPath(): DeleteEntryRequest {
-    return {
-        id: uuidv4()
-    };
+    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-01)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
 }
+
+/**
+ * AC-02 — Non-2xx Response request.
+ *
+ * Builds a syntactically valid request used for transport-level error tests
+ * (e.g., 400/404/500). The request itself is correct; only HTTP status differs.
+ *
+ * @returns {DeleteEntryRequest} Valid request for non-2xx scenarios.
+ */
 
 /**
  * AC-02: any valid UUID; value is irrelevant for non-2xx checks.
  */
 export function ac02Non2xxResponse(): DeleteEntryRequest {
-    return {
-        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
-    };
+    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-02)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
 }
 
 /**
- * AC-03 — Malformed JSON (success:true but no data)
- * Uses a stable UUID; value irrelevant for this test.
+ * AC-03 — Malformed JSON request.
+ *
+ * Builds a valid request intended for tests where the server responds
+ * with a malformed JSON body (e.g., missing `data` even though success=true).
+ * The request is valid by design.
+ *
+ * @returns {DeleteEntryRequest} Valid request for malformed JSON scenarios.
  */
 export function ac03MalformedJson(): DeleteEntryRequest {
-    return {
-        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
-    };
+    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-03)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
 }
 
 /**
  * AC-04 — Contract guard (success:false with 200).
- * Uses a stable UUID; concrete value is irrelevant for this check.
+ *
+ * Builds a valid request used in tests where the API responds with
+ * { success:false } and HTTP status 200 (logical failure branch).
+ *
+ * @returns {DeleteEntryRequest} Valid request for success=false scenarios.
  */
-export function ac04SuccessFalse(): DeleteEntryRequest {
-    return {
-        id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
-    };
+export function ac04SuccessFalse(): {id: string} {
+    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-04)'});
+
+    const id = entry.id;
+    const payload = {id};
+
+    return payload;
 }

--- a/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
@@ -10,3 +10,12 @@ export function ac01HappyPath(): DeleteEntryRequest {
         id: uuidv4()
     };
 }
+
+/**
+ * AC-02: any valid UUID; value is irrelevant for non-2xx checks.
+ */
+export function ac02Non2xxResponse(): DeleteEntryRequest {
+    return {
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    };
+}

--- a/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
@@ -21,3 +21,35 @@ export function ac01HappyPath(req: DeleteEntryRequest): DeleteEntryResponse {
         data: entry
     };
 }
+
+/**
+ * AC-03 — Malformed JSON (structural).
+ *
+ * Builds a syntactically valid payload that violates the success=true branch
+ * of UseCaseResponse by omitting the required `data` field.
+ * Used to ensure the gateway rejects such responses as malformed.
+ *
+ * @typedef MalformedDeleteEntrySuccessPayload
+ * A payload with success=true and missing `data` on purpose.
+ */
+export interface MalformedDeleteEntrySuccessPayload {
+    success: true;
+    status: number;
+    // intentionally no `data`
+}
+
+/**
+ * @param {DeleteEntryRequest} _request Accepted for signature consistency; intentionally unused.
+ * @returns {MalformedDeleteEntrySuccessPayload} success=true payload without `data`.
+ */
+export function ac03MalformedJson(_request: DeleteEntryRequest): MalformedDeleteEntrySuccessPayload {
+    void _request;
+
+    const payload: MalformedDeleteEntrySuccessPayload = {
+        success: true,
+        status: 200
+        // intentionally missing `data`
+    };
+
+    return payload;
+}

--- a/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
@@ -1,0 +1,23 @@
+import type {DeleteEntryResponse} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryResponse';
+import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
+
+/**
+ * Response factory for UC-4 DeleteEntry.
+ * AC-01 returns success:true with a full Entry object in data.
+ */
+export function ac01HappyPath(req: DeleteEntryRequest): DeleteEntryResponse {
+    const entry = {
+        id: req.id,
+        title: 'Valid title',
+        body: 'Valid body',
+        date: '2025-02-12',
+        createdAt: '2025-10-09T12:01:57+00:00',
+        updatedAt: '2025-10-09T12:02:00+00:00'
+    };
+
+    return {
+        success: true,
+        status: 200,
+        data: entry
+    };
+}

--- a/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
@@ -1,3 +1,5 @@
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+
 import type {DeleteEntryResponse} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryResponse';
 import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/DeleteEntryRequest';
 
@@ -6,20 +8,15 @@ import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/
  * AC-01 returns success:true with a full Entry object in data.
  */
 export function ac01HappyPath(req: DeleteEntryRequest): DeleteEntryResponse {
-    const entry = {
-        id: req.id,
-        title: 'Valid title',
-        body: 'Valid body',
-        date: '2025-02-12',
-        createdAt: '2025-10-09T12:01:57+00:00',
-        updatedAt: '2025-10-09T12:02:00+00:00'
-    };
+    const item = EntryFactory.make(req);
 
-    return {
+    const response: DeleteEntryResponse = {
         success: true,
         status: 200,
-        data: entry
+        data: item
     };
+
+    return response;
 }
 
 /**

--- a/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/DeleteEntryResponseFactory.ts
@@ -42,13 +42,32 @@ export interface MalformedDeleteEntrySuccessPayload {
  * @param {DeleteEntryRequest} _request Accepted for signature consistency; intentionally unused.
  * @returns {MalformedDeleteEntrySuccessPayload} success=true payload without `data`.
  */
-export function ac03MalformedJson(_request: DeleteEntryRequest): MalformedDeleteEntrySuccessPayload {
+export function ac03MalformedJson(
+    _request: DeleteEntryRequest
+): MalformedDeleteEntrySuccessPayload {
     void _request;
 
     const payload: MalformedDeleteEntrySuccessPayload = {
         success: true,
         status: 200
         // intentionally missing `data`
+    };
+
+    return payload;
+}
+
+/**
+ * AC-04 — Contract guard payload.
+ * Backend should NOT return success:false with 200; if it does, gateway must reject as malformed.
+ */
+export function ac04SuccessFalse(_req: DeleteEntryRequest): DeleteEntryResponse {
+    void _req;
+
+    // success:false + 200 (no data by contract on error-like responses)
+    const payload: DeleteEntryResponse = {
+        success: false,
+        status: 200
+        // code is optional per UseCaseResponse; omitted intentionally
     };
 
     return payload;


### PR DESCRIPTION
Implements DeleteEntry gateway following the unified UC-1/2/3 pattern: typed UseCaseResponse, strict transport checks. 
Adds AC-01 Happy, AC-02 Non-2xx (400/500), AC-03 Malformed, AC-04 contract guard. 
Request factories return DTO type; response factory uses EntryFactory.

Resolves #23 