### PR TITLE
refactor(tests): UC-2 ListEntries — request factory to DTO return + DRY payload builder

### DIFF
--- a/frontend/tests/helpers/http/requests/entries/AddEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/AddEntryRequestFactory.ts
@@ -1,6 +1,29 @@
 // UC-1 AddEntry — Request factory (AC01–AC04).
-// Returns plain request objects without importing types from src.
 import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {AddEntryRequest} from '@src/Application/DTO/Entries/AddEntry/AddEntryRequest';
+
+/**
+ * Builds a `{title, body, date}` request payload using EntryFactory as the single source of truth.
+ *
+ * Purpose: generate a valid AddEntryRequest without hard-coded data; the title embeds UC/AC
+ * for traceability in test data.
+ *
+ * @param {string} uc Use case label, e.g. "UC-04".
+ * @param {string} ac Acceptance criteria label, e.g. "AC-02".
+ *
+ * @returns {AddEntryRequest} Request payload with a valid entry id.
+ */
+function getPayload(uc: string, ac: string): AddEntryRequest {
+    const title = `Valid title (${uc}, ${ac})`;
+    const entry = EntryFactory.make({title});
+
+    const body = entry.body;
+    const date = entry.date;
+
+    const payload: AddEntryRequest = {title, body, date};
+
+    return payload;
+}
 
 /**
  * AC-01 — Happy Path payload.
@@ -9,13 +32,10 @@ import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
  * Extracts title, body, and date via destructuring for consistency
  * with domain Entry shape.
  *
- * @return {{title: string, body: string, date: string}} Valid AddEntry request body.
+ * @return {AddEntryRequest} Valid AddEntry request body.
  */
-export function ac01HappyPath(): {title: string; body: string; date: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-01)'});
-
-    const {title, body, date} = entry;
-    const payload = {title, body, date};
+export function ac01HappyPath(): AddEntryRequest {
+    const payload = getPayload('UC-01', 'AC-01');
 
     return payload;
 }
@@ -28,14 +48,11 @@ export function ac01HappyPath(): {title: string; body: string; date: string} {
  * Extracts only title, body, and date from EntryFactory output
  * to stay consistent with domain Entry shape.
  *
- * @return {{title: string, body: string, date: string}} Valid request for non-2xx tests.
+ * @return {AddEntryRequest} Valid request for non-2xx tests.
  */
-export function ac02Non2xxResponse(): {title: string; body: string; date: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-02)'});
+export function ac02Non2xxResponse(): AddEntryRequest {
+    const payload = getPayload('UC-01', 'AC-02');
 
-    const {title, body, date} = entry;
-
-    const payload = {title, body, date};
     return payload;
 }
 
@@ -47,14 +64,11 @@ export function ac02Non2xxResponse(): {title: string; body: string; date: string
  * (e.g., missing data.item or invalid shape).
  * The request itself is completely valid; only the response is corrupted.
  *
- * @return {{title: string, body: string, date: string}} Valid AddEntry request for malformed JSON tests.
+ * @return {AddEntryRequest} Valid AddEntry request for malformed JSON tests.
  */
-export function ac03MalformedJson(): {title: string; body: string; date: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-03)'});
+export function ac03MalformedJson(): AddEntryRequest {
+    const payload = getPayload('UC-01', 'AC-03');
 
-    const {title, body, date} = entry;
-
-    const payload = {title, body, date};
     return payload;
 }
 
@@ -65,13 +79,10 @@ export function ac03MalformedJson(): {title: string; body: string; date: string}
  * where the server responds with { success: false } but HTTP status is 200.
  * The request itself is correct; only the logical outcome differs.
  *
- * @return {{title: string, body: string, date: string}} Valid AddEntry request for success=false tests.
+ * @return {AddEntryRequest} Valid AddEntry request for success=false tests.
  */
-export function ac04SuccessFalse(): {title: string; body: string; date: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-01, AC-04)'});
+export function ac04SuccessFalse(): AddEntryRequest {
+    const payload = getPayload('UC-01', 'AC-04');
 
-    const {title, body, date} = entry;
-
-    const payload = {title, body, date};
     return payload;
 }

--- a/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/DeleteEntryRequestFactory.ts
@@ -3,6 +3,26 @@ import type {DeleteEntryRequest} from '@src/Application/DTO/Entries/DeleteEntry/
 import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
 
 /**
+ * Builds a `{ id }` request payload using EntryFactory as the single source of truth.
+ *
+ * Purpose: generate a valid DeleteEntryRequest without hard-coded UUIDs; the title embeds UC/AC
+ * for traceability in test data.
+ *
+ * @param {string} uc Use case label, e.g. "UC-04".
+ * @param {string} ac Acceptance criteria label, e.g. "AC-02".
+ * @returns {DeleteEntryRequest} Request payload with a valid entry id.
+ */
+function getPayload(uc: string, ac: string): DeleteEntryRequest {
+    const title = `Valid title (${uc}, ${ac})`;
+    const entry = EntryFactory.make({title});
+
+    const id = entry.id;
+    const payload: DeleteEntryRequest = {id};
+
+    return payload;
+}
+
+/**
  * AC-01 — Happy Path request.
  *
  * Builds a request object with a valid UUID taken from EntryFactory.
@@ -11,10 +31,7 @@ import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
  * @returns {DeleteEntryRequest} Valid request for happy path.
  */
 export function ac01HappyPath(): DeleteEntryRequest {
-    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-01)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-04', 'AC-01');
 
     return payload;
 }
@@ -32,10 +49,7 @@ export function ac01HappyPath(): DeleteEntryRequest {
  * AC-02: any valid UUID; value is irrelevant for non-2xx checks.
  */
 export function ac02Non2xxResponse(): DeleteEntryRequest {
-    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-02)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-04', 'AC-02');
 
     return payload;
 }
@@ -50,10 +64,7 @@ export function ac02Non2xxResponse(): DeleteEntryRequest {
  * @returns {DeleteEntryRequest} Valid request for malformed JSON scenarios.
  */
 export function ac03MalformedJson(): DeleteEntryRequest {
-    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-03)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-04', 'AC-03');
 
     return payload;
 }
@@ -67,10 +78,7 @@ export function ac03MalformedJson(): DeleteEntryRequest {
  * @returns {DeleteEntryRequest} Valid request for success=false scenarios.
  */
 export function ac04SuccessFalse(): {id: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-04, AC-04)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-04', 'AC-04');
 
     return payload;
 }

--- a/frontend/tests/helpers/http/requests/entries/GetEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/GetEntryRequestFactory.ts
@@ -1,6 +1,27 @@
 // UC-3 GetEntry — Request factory (AC01–AC04).
-// Returns plain request objects without importing types from src.
 import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {GetEntryRequest} from '@src/Application/DTO/Entries/GetEntry/GetEntryRequest';
+
+/**
+ * Builds a `{ id }` request payload using EntryFactory as the single source of truth.
+ *
+ * Purpose: generate a valid GetEntryRequest without hard-coded UUIDs; the title embeds UC/AC
+ * for traceability in test data.
+ *
+ * @param {string} uc Use case label, e.g. "UC-04".
+ * @param {string} ac Acceptance criteria label, e.g. "AC-02".
+ *
+ * @returns {GetEntryRequest} Request payload with a valid entry id.
+ */
+function getPayload(uc: string, ac: string): GetEntryRequest {
+    const title = `Valid title (${uc}, ${ac})`;
+    const entry = EntryFactory.make({title});
+
+    const id = entry.id;
+    const payload: GetEntryRequest = {id};
+
+    return payload;
+}
 
 /**
  * AC-01 — Happy Path request.
@@ -8,13 +29,10 @@ import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
  * Builds a request object with a valid UUID taken from EntryFactory.
  * This mirrors real-world usage where the client already knows the entry ID.
  *
- * @returns {{id: string}} Valid GetEntry request payload.
+ * @returns {GetEntryRequest} Valid GetEntry request payload.
  */
 export function ac01HappyPath(): {id: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-01)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-03', 'AC-01');
 
     return payload;
 }
@@ -25,13 +43,10 @@ export function ac01HappyPath(): {id: string} {
  * Builds a syntactically valid request used for transport-level error tests
  * (e.g., 400/404/500). The request itself is correct; only HTTP status differs.
  *
- * @returns {{id: string}} Valid request for non-2xx scenarios.
+ * @returns {GetEntryRequest} Valid request for non-2xx scenarios.
  */
 export function ac02Non2xxResponse(): {id: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-02)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-03', 'AC-02');
 
     return payload;
 }
@@ -43,13 +58,10 @@ export function ac02Non2xxResponse(): {id: string} {
  * with a malformed JSON body (e.g., missing `data` even though success=true).
  * The request is valid by design.
  *
- * @returns {{id: string}} Valid request for malformed JSON scenarios.
+ * @returns {GetEntryRequest} Valid request for malformed JSON scenarios.
  */
 export function ac03MalformedJson(): {id: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-03)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-03', 'AC-03');
 
     return payload;
 }
@@ -60,13 +72,10 @@ export function ac03MalformedJson(): {id: string} {
  * Builds a valid request used in tests where the API responds with
  * { success:false } and HTTP status 200 (logical failure branch).
  *
- * @returns {{id: string}} Valid request for success=false scenarios.
+ * @returns {GetEntryRequest} Valid request for success=false scenarios.
  */
 export function ac04SuccessFalse(): {id: string} {
-    const entry = EntryFactory.make({title: 'Valid title (UC-03, AC-04)'});
-
-    const id = entry.id;
-    const payload = {id};
+    const payload = getPayload('UC-03', 'AC-04');
 
     return payload;
 }

--- a/frontend/tests/helpers/http/requests/entries/ListEntriesRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/ListEntriesRequestFactory.ts
@@ -1,104 +1,95 @@
 // UC-2 ListEntries — Request factory (AC01–AC04).
-// Returns plain request objects without importing types from src.
+import type {ListEntriesRequest} from '@src/Application/DTO/Entries/ListEntries/ListEntriesRequest';
+
+/**
+ * Builds a ListEntriesRequest payload using a single builder to keep scenarios consistent.
+ *
+ * Purpose: generate valid request objects without hard-coded literals at call sites.
+ * The `query` embeds UC/AC labels for traceability in test data.
+ *
+ * @param {string} uc Use case label, e.g., "UC-02".
+ * @param {string} ac Acceptance criteria label, e.g., "AC-01".
+ * @param {Partial<ListEntriesRequest>} overrides Optional per-scenario overrides (e.g., sortField).
+ * @returns {ListEntriesRequest} Valid ListEntries request payload.
+ */
+function getPayload(
+    uc: string,
+    ac: string,
+    overrides: Partial<ListEntriesRequest> = {}
+): ListEntriesRequest {
+    const query = `valid query (${uc}, ${ac})`;
+    const page = 1;
+    const perPage = 10;
+    const sortField = 'updatedAt' as const;
+    const sortDir = 'DESC' as const;
+
+    const base: ListEntriesRequest = {
+        query,
+        page,
+        perPage,
+        sortField,
+        sortDir
+        // dateFrom/dateTo are optional
+    };
+
+    const payload: ListEntriesRequest = {...base, ...overrides};
+
+    return payload;
+}
 
 /**
  * AC-01 — Happy Path request.
  *
- * Builds a valid query with explicit pagination and sorting.
- * Mirrors a typical client request to fetch the latest entries by updatedAt.
+ * Builds a valid query with explicit pagination and default sorting by updatedAt DESC.
+ * Mirrors a typical client request to fetch the latest entries.
  *
- * @returns {{
- *   query?: string,
- *   page?: number,
- *   perPage?: number,
- *   sortField?: 'date'|'updatedAt',
- *   sortDir?: 'ASC'|'DESC',
- *   dateFrom?: string,
- *   dateTo?: string
- * }} Valid ListEntries request.
+ * @returns {ListEntriesRequest} Valid ListEntries request.
  */
-export function ac01HappyPath(): {
-    query?: string;
-    page?: number;
-    perPage?: number;
-    sortField?: 'date' | 'updatedAt';
-    sortDir?: 'ASC' | 'DESC';
-    dateFrom?: string;
-    dateTo?: string;
-} {
-    // prettier-ignore
-    {
-        const query     = 'hello';
-        const page      = 1;
-        const perPage   = 10;
-        const sortField = 'updatedAt' as const;
-        const sortDir   = 'DESC' as const;
+export function ac01HappyPath(): ListEntriesRequest {
+    const payload = getPayload('UC-02', 'AC-01');
 
-        const payload = {query, page, perPage, sortField, sortDir};
-
-        return payload;
-    }
+    return payload;
 }
 
 /**
  * AC-02 — Non-2xx Response request.
  *
- * Builds a syntactically valid request intended for transport-level error tests
- * (e.g., 400/500). The request itself is correct; only HTTP status differs.
+ * Builds a syntactically valid request intended for transport-level error tests (HTTP 400/500).
+ * Uses sorting by date DESC to differ from AC-01 while remaining valid.
+ *
+ * @returns {ListEntriesRequest} Valid request for non-2xx tests.
  */
-export function ac02Non2xxResponse() {
-    // prettier-ignore
-    {
-        const query     = 'status-check';
-        const page      = 1;
-        const perPage   = 10;
-        const sortField = 'date' as const;
-        const sortDir   = 'DESC' as const;
+export function ac02Non2xxResponse(): ListEntriesRequest {
+    const overrides: Partial<ListEntriesRequest> = {sortField: 'date'};
 
-        const payload = {query, page, perPage, sortField, sortDir};
-
-        return payload;
-    }
+    const payload = getPayload('UC-02', 'AC-02', overrides);
+    return payload;
 }
 
 /**
  * AC-03 — Malformed JSON request.
  *
- * Builds a valid request used in tests where the server responds with
- * success=true but malformed `data` (e.g., missing items or wrong shapes).
+ * Builds a valid request used in tests where the server responds with success=true
+ * but malformed `data` (e.g., missing items or invalid shape). The request itself is valid.
+ *
+ * @returns {ListEntriesRequest} Valid request for malformed JSON tests.
  */
-export function ac03MalformedJson() {
-    // prettier-ignore
-    {
-        const query     = 'malformed';
-        const page      = 1;
-        const perPage   = 10;
-        const sortField = 'updatedAt' as const;
-        const sortDir   = 'DESC' as const;
+export function ac03MalformedJson(): ListEntriesRequest {
+    const payload = getPayload('UC-02', 'AC-03');
 
-        const payload = {query, page, perPage, sortField, sortDir};
-
-        return payload;
-    }
+    return payload;
 }
 
 /**
- * AC-04 — success=false request.
+ * AC-04 — Success=false request (contract guard).
  *
- * Builds a valid request used in tests where the API responds with
- * { success:false } and HTTP status 200 (logical failure branch).
+ * Builds a valid request used in tests where the API responds with { success:false }
+ * together with HTTP 200 (logical failure branch). The request is correct; only outcome differs.
+ *
+ * @returns {ListEntriesRequest} Valid request for success=false tests.
  */
-export function ac04SuccessFalse() {
-    // prettier-ignore
-    {
-        const query     = 'logical-failure';
-        const page      = 1;
-        const perPage   = 10;
-        const sortField = 'updatedAt' as const;
-        const sortDir   = 'DESC' as const;
+export function ac04SuccessFalse(): ListEntriesRequest {
+    const payload = getPayload('UC-02', 'AC-04');
 
-        const payload = {query, page, perPage, sortField, sortDir};
-
-        return payload;
-    }
+    return payload;
 }


### PR DESCRIPTION
Refactors request factor to match the DeleteEntry style: introduces a single internal getPayload(uc, ac, overrides) builder, returns the DTO type for each request (no inline types), removes duplication across AC-01…AC-04.

No functional changes—test infrastructure only.

Resolves #30