### PR TITLE
test(unit): add UC-5 UpdateEntry tests (AC01–AC04)

### DIFF
--- a/frontend/src/Application/DTO/Entries/UpdateEntry/UpdateEntryRequest.ts
+++ b/frontend/src/Application/DTO/Entries/UpdateEntry/UpdateEntryRequest.ts
@@ -1,0 +1,12 @@
+/**
+ * UC-5: Update Entry — request DTO.
+ *
+ * Represents the transport-level payload to update an existing entry.
+ * Gateway enforces only transport shape; business rules are validated elsewhere.
+ */
+export type UpdateEntryRequest = {
+    id: string;
+    title?: string;
+    body?: string;
+    date?: string; // strict YYYY-MM-DD
+};

--- a/frontend/src/Application/DTO/Entries/UpdateEntry/UpdateEntryResponse.ts
+++ b/frontend/src/Application/DTO/Entries/UpdateEntry/UpdateEntryResponse.ts
@@ -1,0 +1,9 @@
+// src/Application/DTO/Entries/UpdateEntry/UpdateEntryResponse.ts
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {Entry} from '@src/Domain/Entries/Entry';
+
+/**
+ * UC-5: Update Entry — response DTO.
+ * Mirrors backend: { success:true, status:200, data: Entry } on success.
+ */
+export type UpdateEntryResponse = UseCaseResponse<Entry>;

--- a/frontend/src/Infrastructure/Entries/UpdateEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/UpdateEntryGateway.ts
@@ -1,0 +1,29 @@
+import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/UpdateEntryRequest';
+
+/**
+ * UC-5: Update Entry (Frontend, Gateway)
+ *
+ * Placeholder stub used for RED phase in TDD.
+ * Implements the interface shape and throws until real logic is written.
+ */
+export class UpdateEntryGateway {
+    private readonly http: HttpClient;
+
+    constructor(http: HttpClient) {
+        this.http = http;
+    }
+
+    /**
+     * Temporary stub for TDD RED phase.
+     *
+     * @param {UpdateEntryRequest} _req UpdateEntry request payload.
+     * @throws {Error} Always, until implemented.
+     */
+    async update(_req: UpdateEntryRequest): Promise<Entry> {
+        void _req;
+        const message = 'Not implemented: UC-5 UpdateEntryGateway.update()';
+        throw new Error(message);
+    }
+}

--- a/frontend/src/Infrastructure/Entries/UpdateEntryGateway.ts
+++ b/frontend/src/Infrastructure/Entries/UpdateEntryGateway.ts
@@ -1,12 +1,18 @@
 import type {HttpClient} from '@src/Infrastructure/Http/HttpClient';
 import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/UpdateEntryRequest';
 
 /**
- * UC-5: Update Entry (Frontend, Gateway)
+ * UC-5: Update Entry (Frontend)
  *
- * Placeholder stub used for RED phase in TDD.
- * Implements the interface shape and throws until real logic is written.
+ * Sends a partial update for an existing entry to PUT /api/entries/:id.
+ *
+ * Performs minimal transport-level validation:
+ * - success must be true;
+ * - data must be a non-null object (backend returns Entry directly in data).
+ *
+ * Does not validate Entry fields — handled on the backend and in higher layers.
  */
 export class UpdateEntryGateway {
     private readonly http: HttpClient;
@@ -16,14 +22,37 @@ export class UpdateEntryGateway {
     }
 
     /**
-     * Temporary stub for TDD RED phase.
+     * UC-5: Update Entry (Frontend, Gateway)
      *
-     * @param {UpdateEntryRequest} _req UpdateEntry request payload.
-     * @throws {Error} Always, until implemented.
+     * Sends UpdateEntry payload to PUT /api/entries/:id and returns the updated Entry.
+     *
+     * Transport-level validation only:
+     * - success must be true;
+     * - data must be a non-null object (backend returns Entry directly in data).
+     *
+     * @param {UpdateEntryRequest} req Valid UpdateEntry request payload.
+     * @returns {Promise<Entry>} Updated entry returned by the server.
+     * @throws {Error} If HTTP status is non-2xx or response structure is invalid.
      */
-    async update(_req: UpdateEntryRequest): Promise<Entry> {
-        void _req;
-        const message = 'Not implemented: UC-5 UpdateEntryGateway.update()';
-        throw new Error(message);
+    async update(req: UpdateEntryRequest): Promise<Entry> {
+        const url = `/api/entries/${req.id}`;
+        const json = await this.http.request<UseCaseResponse<Entry>>('PUT', url, req);
+
+        if (json.success !== true) {
+            const message = 'Malformed response for PUT /api/entries/:id';
+
+            throw new Error(message);
+        }
+
+        const hasData = typeof json.data === 'object' && json.data !== null;
+        if (!hasData) {
+            const message = 'Malformed response for PUT /api/entries/:id';
+
+            throw new Error(message);
+        }
+
+        const entry = json.data as Entry;
+
+        return entry;
     }
 }

--- a/frontend/tests/Unit/Entries/UpdateEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Entries/UpdateEntry/AC01_HappyPath.test.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseUpdateEntryGatewayTest';
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/UpdateEntryRequestFactory';
+import {ac01HappyPath as makeResponse} from '@tests/helpers/http/responses/entries/UpdateEntryResponseFactory';
+import {ensureSuccess} from '@tests/helpers/asserts';
+
+/**
+ * UC-5: Update Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that UpdateEntryGateway resolves with Entry when API responds
+ * 200 + { success: true, data }.
+ *
+ * Mechanics:
+ * - Build request via factory (no literals at call site).
+ * - Build matching response via response factory from the same request.
+ * - Mock HTTP once with JSON payload and status 200.
+ * - Assert gateway returns Entry consistent with response.data.
+ *
+ * Case:
+ * - AC-01 — Happy path with success=true and well-formed JSON.
+ */
+describe('AC01 — UpdateEntryGateway returns updated entry (mocked)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('returns updated entry when called with valid payload', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request);
+
+        // Guard: ensure success branch with `data` is selected.
+        const okResponse = ensureSuccess(response);
+
+        // Act
+        mockJsonOnce(ctx.fetchMock, 200, okResponse);
+        const entry = await ctx.gateway.update(request);
+
+        // Assert
+        expect(entry.id).toBe(okResponse.data.id);
+        expect(entry.title).toBe(okResponse.data.title);
+        expect(entry.body).toBe(okResponse.data.body);
+        expect(entry.date).toBe(okResponse.data.date);
+        expect(typeof entry.createdAt).toBe('string');
+        expect(typeof entry.updatedAt).toBe('string');
+        expect(entry.createdAt <= entry.updatedAt).toBe(true);
+    });
+});

--- a/frontend/tests/Unit/Entries/UpdateEntry/AC02_Non2xxResponse.test.ts
+++ b/frontend/tests/Unit/Entries/UpdateEntry/AC02_Non2xxResponse.test.ts
@@ -1,0 +1,65 @@
+// tests/Unit/Entries/UpdateEntry/AC02_Non2xxResponse.test.ts
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseUpdateEntryGatewayTest';
+import {ac02Non2xxResponse as makeRequest} from '@tests/helpers/http/requests/entries/UpdateEntryRequestFactory';
+import {
+    makeBadRequest,
+    makeInternalError
+} from '@tests/helpers/http/responses/common/Non2xxResponseFactory';
+
+/**
+ * UC-5: Update Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that UpdateEntryGateway rejects on generic non-2xx HTTP responses.
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Use common non-2xx response factories (no domain codes asserted here).
+ * - Mock fetch with 400/500 and assert rejection (message includes status).
+ *
+ * Cases:
+ * - AC-02a — 400 Bad Request → rejects with HttpError (message mentions 400).
+ * - AC-02b — 500 Internal Server Error → rejects with HttpError (message mentions 500).
+ */
+describe('AC02 — UpdateEntryGateway throws on non-2xx response (generic)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when API responds with 400 Bad Request', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeBadRequest();
+
+        // Act
+        mockJsonOnce(ctx.fetchMock, 400, response);
+        const fn = ctx.gateway.update(request);
+
+        // Assert
+        const message = /400|bad request/i;
+        await expect(fn).rejects.toThrowError(message);
+    });
+
+    it('throws when API responds with 500 Internal Server Error', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeInternalError();
+
+        // Act
+        mockJsonOnce(ctx.fetchMock, 500, response);
+        const fn = ctx.gateway.update(request);
+
+        // Assert
+        const message = /500|internal/i;
+        await expect(fn).rejects.toThrowError(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/UpdateEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/UpdateEntry/AC03_MalformedJson.test.ts
@@ -1,0 +1,47 @@
+// tests/Unit/Entries/UpdateEntry/AC03_MalformedJson.test.ts
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseUpdateEntryGatewayTest';
+import {ac03MalformedJson as makeRequest} from '@tests/helpers/http/requests/entries/UpdateEntryRequestFactory';
+import {ac03MalformedJson as makeResponse} from '@tests/helpers/http/responses/entries/UpdateEntryResponseFactory';
+
+/**
+ * UC-5: Update Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that UpdateEntryGateway rejects when backend sends success=true
+ * but the JSON payload is malformed (e.g., missing `data`).
+ *
+ * Mechanics:
+ * - Build a valid request via factory (no literals).
+ * - Build a malformed success payload via response factory (no `data`).
+ * - Mock fetch with 200 and assert rejection (message indicates malformed).
+ *
+ * Case:
+ * - AC-03 — Malformed JSON on success=true branch.
+ */
+describe('AC03 — UpdateEntryGateway rejects on malformed JSON (success=true, no data)', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when success=true but `data` is missing', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:true, but no `data`
+
+        // Act
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const fn = ctx.gateway.update(request);
+
+        // Assert
+        const message = /malformed|invalid/i;
+        await expect(fn).rejects.toThrowError(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/UpdateEntry/AC03_MalformedJson.test.ts
+++ b/frontend/tests/Unit/Entries/UpdateEntry/AC03_MalformedJson.test.ts
@@ -41,7 +41,7 @@ describe('AC03 — UpdateEntryGateway rejects on malformed JSON (success=true, n
         const fn = ctx.gateway.update(request);
 
         // Assert
-        const message = /malformed|invalid/i;
+        const message = 'Malformed response for PUT /api/entries/:id';
         await expect(fn).rejects.toThrowError(message);
     });
 });

--- a/frontend/tests/Unit/Entries/UpdateEntry/AC04_SuccessFalse.test.ts
+++ b/frontend/tests/Unit/Entries/UpdateEntry/AC04_SuccessFalse.test.ts
@@ -1,0 +1,47 @@
+// tests/Unit/Entries/UpdateEntry/AC04_SuccessFalse.test.ts
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {createGateway, mockJsonOnce, type GatewayTestCtx} from './BaseUpdateEntryGatewayTest';
+import {ac04SuccessFalse as makeRequest} from '@tests/helpers/http/requests/entries/UpdateEntryRequestFactory';
+import {ac04SuccessFalse as makeResponse} from '@tests/helpers/http/responses/entries/UpdateEntryResponseFactory';
+
+/**
+ * UC-5: Update Entry (Frontend, Gateway)
+ *
+ * Purpose:
+ * Verify that UpdateEntryGateway rejects when backend returns
+ * { success:false, status:200, code:... } for logical failure.
+ *
+ * Mechanics:
+ * - Build valid request via factory.
+ * - Build success=false payload via response factory.
+ * - Mock fetch with HTTP 200 and assert rejection (message indicates malformed).
+ *
+ * Case:
+ * - AC-04 — success=false (200) must be rejected by transport checks.
+ */
+describe('AC04 — UpdateEntryGateway rejects when success=false with HTTP 200', () => {
+    let ctx: GatewayTestCtx;
+
+    beforeEach(() => {
+        ctx = createGateway();
+    });
+
+    afterEach(() => {
+        ctx.cleanup();
+    });
+
+    it('throws when backend responds {success:false, status:200}', async () => {
+        // Arrange
+        // prettier-ignore
+        const request  = makeRequest();
+        const response = makeResponse(request); // success:false, 200
+
+        // Act
+        mockJsonOnce(ctx.fetchMock, 200, response);
+        const fn = ctx.gateway.update(request);
+
+        // Assert
+        const message = 'Malformed response for PUT /api/entries/:id';
+        await expect(fn).rejects.toThrowError(message);
+    });
+});

--- a/frontend/tests/Unit/Entries/UpdateEntry/BaseUpdateEntryGatewayTest.ts
+++ b/frontend/tests/Unit/Entries/UpdateEntry/BaseUpdateEntryGatewayTest.ts
@@ -1,0 +1,24 @@
+import {
+    type HttpTestCtxBase,
+    makeGatewayCtx,
+    mockJsonOnce
+} from '@tests/Unit/Entries/BaseEntriesGatewayTest';
+import {UpdateEntryGateway} from '@src/Infrastructure/Entries/UpdateEntryGateway';
+
+export type GatewayTestCtx = HttpTestCtxBase & {
+    gateway: UpdateEntryGateway;
+};
+
+/**
+ * Provides a mocked UpdateEntryGateway built over shared HTTP test context.
+ *
+ * Mechanics:
+ * - Uses common makeGatewayCtx(...) to wire gateway over stubbed HttpClient.
+ * - Re-exports mockJsonOnce to enqueue one transport envelope per test.
+ */
+export function createGateway(baseUrl: string = 'http://localhost'): GatewayTestCtx {
+    const ctx = makeGatewayCtx(UpdateEntryGateway, baseUrl);
+    return ctx as GatewayTestCtx;
+}
+
+export {mockJsonOnce};

--- a/frontend/tests/helpers/http/requests/entries/UpdateEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/UpdateEntryRequestFactory.ts
@@ -13,10 +13,10 @@ import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/
 function getPayload(uc: string, ac: string): UpdateEntryRequest {
     const base = EntryFactory.make(); // source of truth for valid fields
 
-    const id    = base.id;
+    const id = base.id;
     const title = `Valid title (updated) (${uc}, ${ac})`;
-    const body  = base.body;
-    const date  = base.date;
+    const body = base.body;
+    const date = base.date;
 
     const payload: UpdateEntryRequest = {id, title, body, date};
     return payload;

--- a/frontend/tests/helpers/http/requests/entries/UpdateEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/UpdateEntryRequestFactory.ts
@@ -11,14 +11,12 @@ import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/
  * - At least one updatable field must be present (title/body/date).
  */
 function getPayload(uc: string, ac: string): UpdateEntryRequest {
-    const base = EntryFactory.make(); // source of truth for valid fields
+    const title = `Valid title (${uc}, ${ac})`;
+    const entry = EntryFactory.make({title});
 
-    const id = base.id;
-    const title = `Valid title (updated) (${uc}, ${ac})`;
-    const body = base.body;
-    const date = base.date;
-
+    const {id, body, date} = entry;
     const payload: UpdateEntryRequest = {id, title, body, date};
+
     return payload;
 }
 

--- a/frontend/tests/helpers/http/requests/entries/UpdateEntryRequestFactory.ts
+++ b/frontend/tests/helpers/http/requests/entries/UpdateEntryRequestFactory.ts
@@ -1,0 +1,67 @@
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/UpdateEntryRequest';
+
+/**
+ * Builds a typed UpdateEntryRequest payload for UC-5 cases.
+ *
+ * Purpose: generate a valid partial update request (id + fields to change)
+ * without literals at call site; the title embeds UC/AC for traceability.
+ *
+ * Notes:
+ * - At least one updatable field must be present (title/body/date).
+ */
+function getPayload(uc: string, ac: string): UpdateEntryRequest {
+    const base = EntryFactory.make(); // source of truth for valid fields
+
+    const id    = base.id;
+    const title = `Valid title (updated) (${uc}, ${ac})`;
+    const body  = base.body;
+    const date  = base.date;
+
+    const payload: UpdateEntryRequest = {id, title, body, date};
+    return payload;
+}
+
+/**
+ * AC-01 — Happy Path payload.
+ *
+ * @returns {UpdateEntryRequest} Valid request for success scenario.
+ */
+export function ac01HappyPath(): UpdateEntryRequest {
+    const payload = getPayload('UC-05', 'AC-01');
+
+    return payload;
+}
+
+/**
+ * AC-02 — Non-2xx Response payload.
+ *
+ * @returns {UpdateEntryRequest} Valid request for generic transport errors.
+ */
+export function ac02Non2xxResponse(): UpdateEntryRequest {
+    const payload = getPayload('UC-05', 'AC-02');
+
+    return payload;
+}
+
+/**
+ * AC-03 — Malformed JSON payload.
+ *
+ * @returns {UpdateEntryRequest} Valid request; response will be malformed.
+ */
+export function ac03MalformedJson(): UpdateEntryRequest {
+    const payload = getPayload('UC-05', 'AC-03');
+
+    return payload;
+}
+
+/**
+ * AC-04 — success=false with 200 payload.
+ *
+ * @returns {UpdateEntryRequest} Valid request; response has success=false.
+ */
+export function ac04SuccessFalse(): UpdateEntryRequest {
+    const payload = getPayload('UC-05', 'AC-04');
+
+    return payload;
+}

--- a/frontend/tests/helpers/http/responses/entries/UpdateEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/UpdateEntryResponseFactory.ts
@@ -13,12 +13,7 @@ import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/
  */
 export function ac01HappyPath(request: UpdateEntryRequest): UseCaseResponse<Entry> {
     // prettier-ignore
-    const item = EntryFactory.make({
-        id   : request.id,
-        title: request.title,
-        body : request.body,
-        date : request.date
-    });
+    const item = EntryFactory.make(request);
 
     // prettier-ignore
     const response: UseCaseResponse<Entry> = {

--- a/frontend/tests/helpers/http/responses/entries/UpdateEntryResponseFactory.ts
+++ b/frontend/tests/helpers/http/responses/entries/UpdateEntryResponseFactory.ts
@@ -1,0 +1,72 @@
+// tests/helpers/http/responses/entries/UpdateEntryResponseFactory.ts
+import {EntryFactory} from '@tests/helpers/factories/EntryFactory';
+import type {Entry} from '@src/Domain/Entries/Entry';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {UpdateEntryRequest} from '@src/Application/DTO/Entries/UpdateEntry/UpdateEntryRequest';
+
+/**
+ * Provides consistent mocked API responses for UC-5 UpdateEntry gateway tests.
+ *
+ * Happy path:
+ * - { success: true, status: 200, data: Entry }
+ * Data mirrors "updated" state derived from request fields.
+ */
+export function ac01HappyPath(request: UpdateEntryRequest): UseCaseResponse<Entry> {
+    // prettier-ignore
+    const item = EntryFactory.make({
+        id   : request.id,
+        title: request.title,
+        body : request.body,
+        date : request.date
+    });
+
+    // prettier-ignore
+    const response: UseCaseResponse<Entry> = {
+        success: true,
+        status : 200,
+        data   : item
+    };
+
+    return response;
+}
+
+/**
+ * AC-03 — Malformed JSON (success=true but missing `data`).
+ */
+export interface MalformedUpdateSuccessPayload {
+    success: true;
+    status: number;
+    // intentionally no `data`
+}
+
+/**
+ * @returns {MalformedUpdateSuccessPayload} success=true payload without `data`.
+ */
+export function ac03MalformedJson(_request: UpdateEntryRequest): MalformedUpdateSuccessPayload {
+    void _request;
+
+    // prettier-ignore
+    const payload: MalformedUpdateSuccessPayload = {
+        success: true,
+        status : 200
+        // no `data`
+    };
+
+    return payload;
+}
+
+/**
+ * AC-04 — success=false with HTTP 200.
+ */
+export function ac04SuccessFalse(_request: UpdateEntryRequest): UseCaseResponse<Entry> {
+    void _request;
+
+    // prettier-ignore
+    const payload: UseCaseResponse<Entry> = {
+        success: false,
+        status : 200,
+        // no data on error branch per our envelope
+    };
+
+    return payload;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
         include: ['tests/**/*.test.ts'],
         reporters: ['default'],
         testTimeout: 5000,
-        silent: false
+        silent: true
     }
 });


### PR DESCRIPTION
Add unit tests for UC-5 Update Entry gateway covering all acceptance criteria (AC01–AC04).
Includes request/response factories, base gateway context, and typed DTO stubs.
Validates transport behavior on success, non-2xx, malformed JSON, and success=false responses.

Resolves #24