### PR TITLE
feat(app): implement UC-2 ListEntries use case via repo.list()

### DIFF
--- a/frontend/src/Application/UseCases/Entries/ListEntries/ListEntries.ts
+++ b/frontend/src/Application/UseCases/Entries/ListEntries/ListEntries.ts
@@ -1,14 +1,46 @@
+import type {EntryRepositoryInterface} from '@src/Domain/Interfaces/Entries/EntryRepositoryInterface';
+import type {ListEntriesRequest} from '@src/Application/DTO/Entries/ListEntries/ListEntriesRequest';
+import type {ListEntriesResponse} from '@src/Application/DTO/Entries/ListEntries/ListEntriesResponse';
+import {ListEntriesCriteriaFactory} from '@src/Application/Factories/ListEntriesCriteriaFactory';
+
 /**
- * Temporary stub for UC-2 ListEntries use case.
+ * UC-2: List Entries — Application use case.
  *
  * Purpose:
- * Allow RED phase of the test to compile before implementation.
- * Throws explicitly to mark unimplemented logic.
+ * Bridge Application DTOs with the domain EntryRepository and
+ * return typed UseCaseResponse envelope on the happy path.
+ *
+ * Mechanics:
+ * - Build criteria via ListEntriesCriteriaFactory.fromRequest(request).
+ * - Delegate to repo.list(criteria).
+ * - Return { success:true, status:200, data: page }.
  */
 export class ListEntries {
-    public constructor(_repo: unknown) {}
+    private readonly repo: EntryRepositoryInterface;
 
-    public async execute(_request: unknown): Promise<never> {
-        throw new Error('Not implemented yet');
+    /**
+     * @param {EntryRepositoryInterface} repo Domain repository dependency (injected).
+     */
+    public constructor(repo: EntryRepositoryInterface) {
+        this.repo = repo;
+    }
+
+    /**
+     * Execute UC-2 with the given request.
+     *
+     * @param {ListEntriesRequest} request
+     * @returns {Promise<ListEntriesResponse>} Success envelope with page data.
+     */
+    public async execute(request: ListEntriesRequest): Promise<ListEntriesResponse> {
+        const criteria = ListEntriesCriteriaFactory.fromRequest(request);
+        const page = await this.repo.list(criteria);
+
+        const response: ListEntriesResponse = {
+            success: true,
+            status: 200,
+            data: page
+        };
+
+        return response;
     }
 }

--- a/frontend/src/Application/UseCases/Entries/ListEntries/ListEntries.ts
+++ b/frontend/src/Application/UseCases/Entries/ListEntries/ListEntries.ts
@@ -1,0 +1,14 @@
+/**
+ * Temporary stub for UC-2 ListEntries use case.
+ *
+ * Purpose:
+ * Allow RED phase of the test to compile before implementation.
+ * Throws explicitly to mark unimplemented logic.
+ */
+export class ListEntries {
+    public constructor(_repo: unknown) {}
+
+    public async execute(_request: unknown): Promise<never> {
+        throw new Error('Not implemented yet');
+    }
+}

--- a/frontend/tests/Unit/Application/UseCases/Entries/ListEntries/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Application/UseCases/Entries/ListEntries/AC01_HappyPath.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @covers ListEntries
+ *
+ * Purpose:
+ * Validate Application UC-2 bridges DTO → domain repo and returns a typed envelope.
+ *
+ * Mechanics:
+ * - Mock EntryRepository.list to return a prepared page.
+ * - Use ListEntriesCriteriaFactory.fromRequest to build expected criteria.
+ *
+ * Cases:
+ * - AC01 Happy path
+ */
+
+import {describe, vi, it, expect, beforeEach} from 'vitest';
+import type {EntryRepositoryInterface} from '@src/Domain/Interfaces/Entries/EntryRepositoryInterface';
+import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
+import {ListEntries} from '@src/Application/UseCases/Entries/ListEntries/ListEntries';
+import {ListEntriesCriteriaFactory} from '@src/Application/Factories/ListEntriesCriteriaFactory';
+
+import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
+import {EntryFactory} from '@tests/helpers/domain/entries/EntryFactory';
+
+describe('AC01 — ListEntries (Application) returns success=true and page', () => {
+    let repo: EntryRepositoryInterface;
+
+    beforeEach(() => {
+        const list = vi.fn();
+        const findById = vi.fn();
+        const deleteById = vi.fn();
+        const save = vi.fn();
+
+        repo = {list, findById, deleteById, save};
+    });
+
+    it('returns { success:true, status:200, data: page } for valid request', async () => {
+        // Arrange
+        const request = makeRequest();
+        const criteria = ListEntriesCriteriaFactory.fromRequest(request);
+
+        const items = [
+            EntryFactory.make({title: 'Valid title #1'}),
+            EntryFactory.make({title: 'Valid title #2'})
+        ];
+
+        const page: ListEntriesPageInterface = {
+            items,
+            page: request.page ?? 1,
+            perPage: request.perPage ?? 10,
+            total: 2,
+            pagesCount: 1
+        };
+
+        const listMock = repo.list as unknown as ReturnType<typeof vi.fn>;
+        listMock.mockResolvedValueOnce(page);
+
+        const uc = new ListEntries(repo);
+
+        // Act
+        const response = await uc.execute(request);
+
+        // Assert
+        expect(response.success).toBe(true);
+        expect(response.status).toBe(200);
+        expect(response.data).toEqual(page);
+
+        expect(listMock).toHaveBeenCalledTimes(1);
+        expect(listMock).toHaveBeenCalledWith(criteria);
+    });
+});


### PR DESCRIPTION
Introduces a minimal Application-level use case for UC-2.
Bridges DTOs with the domain repository and returns a typed ListEntriesResponse.

Resolves #39