### PR TITLE
feat(application): implement UC-3 GetEntry use case with unit tests

### DIFF
--- a/frontend/src/Application/UseCases/Entries/GetEntry/GetEntry.ts
+++ b/frontend/src/Application/UseCases/Entries/GetEntry/GetEntry.ts
@@ -1,0 +1,37 @@
+import type {EntryRepositoryInterface} from '@src/Domain/Interfaces/Entries/EntryRepositoryInterface';
+import type {GetEntryRequest} from '@src/Application/DTO/Entries/GetEntry/GetEntryRequest';
+import type {GetEntryResponse} from '@src/Application/DTO/Entries/GetEntry/GetEntryResponse';
+
+/**
+ * UC-3: Get Entry — Application use case.
+ *
+ * Purpose:
+ * Bridge Application DTO (id) with the domain EntryRepository and
+ * return a typed UseCaseResponse envelope for both success and 404 branches.
+ *
+ * Mechanics:
+ * - Extract id from request.
+ * - Call repo.findById(id).
+ * - If found → { success:true, status:200, data: entry }.
+ * - If not found → { success:false, status:404, code:'ENTRY_NOT_FOUND' }.
+ */
+export class GetEntry {
+    private readonly repo: EntryRepositoryInterface;
+
+    /**
+     * @param {EntryRepositoryInterface} repo Domain repository dependency (injected).
+     */
+    public constructor(repo: EntryRepositoryInterface) {
+        this.repo = repo;
+    }
+
+    /**
+     * Execute UC-3 with the given request.
+     *
+     * @param {GetEntryRequest} request DTO with the entry identifier.
+     * @returns {Promise<GetEntryResponse>} Typed transport envelope for UI.
+     */
+    public async execute(request: GetEntryRequest): Promise<GetEntryResponse> {
+        throw new Error("Not implemented");
+    }
+}

--- a/frontend/src/Application/UseCases/Entries/GetEntry/GetEntry.ts
+++ b/frontend/src/Application/UseCases/Entries/GetEntry/GetEntry.ts
@@ -32,6 +32,25 @@ export class GetEntry {
      * @returns {Promise<GetEntryResponse>} Typed transport envelope for UI.
      */
     public async execute(request: GetEntryRequest): Promise<GetEntryResponse> {
-        throw new Error("Not implemented");
+        const id = request.id;
+        const entry = await this.repo.findById(id);
+
+        if (entry) {
+            const response: GetEntryResponse = {
+                success: true,
+                status: 200,
+                data: entry
+            };
+
+            return response;
+        }
+
+        const notFound: GetEntryResponse = {
+            success: false,
+            status: 404,
+            code: 'ENTRY_NOT_FOUND'
+        };
+
+        return notFound;
     }
 }

--- a/frontend/tests/Unit/Application/UseCases/Entries/GetEntry/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Application/UseCases/Entries/GetEntry/AC01_HappyPath.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @covers GetEntry
+ * @group Application
+ *
+ * Purpose:
+ * Validate that UC-3 returns { success:true, status:200, data: Entry } when repository finds the entry.
+ *
+ * Mechanics:
+ * - Mock EntryRepository.findById to resolve a concrete Entry object.
+ * - Build request with the same id.
+ * - Assert response envelope and repository interaction.
+ */
+
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import type {EntryRepositoryInterface} from '@src/Domain/Interfaces/Entries/EntryRepositoryInterface';
+import {GetEntry} from '@src/Application/UseCases/Entries/GetEntry/GetEntry';
+
+import {EntryFactory} from '@tests/helpers/domain/entries/EntryFactory';
+
+describe('AC01 — GetEntry returns success=true and entry (Application)', () => {
+    let repo: EntryRepositoryInterface;
+
+    beforeEach(() => {
+        const list = vi.fn();
+        const findById = vi.fn();
+        const deleteById = vi.fn();
+        const save = vi.fn();
+
+        repo = {list, findById, deleteById, save};
+    });
+
+    it('returns { success:true, status:200, data: entry } when entry exists', async () => {
+        // Arrange
+        const existing = EntryFactory.make({title: 'Valid title'});
+        const id = existing.id;
+
+        const findByIdMock = repo.findById as unknown as ReturnType<typeof vi.fn>;
+        findByIdMock.mockResolvedValueOnce(existing);
+
+        const uc = new GetEntry(repo);
+        const request = {id};
+
+        // Act
+        const response = await uc.execute(request);
+
+        // Assert
+        expect(response.success).toBe(true);
+        expect(response.status).toBe(200);
+        expect(response.data).toEqual(existing);
+
+        expect(findByIdMock).toHaveBeenCalledTimes(1);
+        expect(findByIdMock).toHaveBeenCalledWith(id);
+    });
+});

--- a/frontend/tests/Unit/Application/UseCases/Entries/GetEntry/AC02_NotFound.test.ts
+++ b/frontend/tests/Unit/Application/UseCases/Entries/GetEntry/AC02_NotFound.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @covers GetEntry
+ * @group Application
+ *
+ * Purpose:
+ * Validate that UC-3 returns { success:false, status:404, code:'ENTRY_NOT_FOUND' } when repository returns null.
+ *
+ * Mechanics:
+ * - Mock EntryRepository.findById to resolve null.
+ * - Build request with arbitrary UUID.
+ * - Assert failure envelope and repository interaction.
+ *
+ * Cases:
+ * - AC02 Not found → 404
+ */
+
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import type {EntryRepositoryInterface} from '@src/Domain/Interfaces/Entries/EntryRepositoryInterface';
+import {GetEntry} from '@src/Application/UseCases/Entries/GetEntry/GetEntry';
+
+import {EntryFactory} from '@tests/helpers/domain/entries/EntryFactory';
+
+describe('AC02 — GetEntry returns success=false and 404 when entry is not found (Application)', () => {
+    let repo: EntryRepositoryInterface;
+
+    beforeEach(() => {
+        const list = vi.fn();
+        const findById = vi.fn();
+        const deleteById = vi.fn();
+        const save = vi.fn();
+
+        repo = {list, findById, deleteById, save};
+    });
+
+    it('returns { success:false, status:404, code:"ENTRY_NOT_FOUND" } when repository returns null', async () => {
+        // Arrange
+        const sample = EntryFactory.make(); // use factory to get a valid-looking UUID
+        const id = sample.id;
+
+        const findByIdMock = repo.findById as unknown as ReturnType<typeof vi.fn>;
+        findByIdMock.mockResolvedValueOnce(null);
+
+        const uc = new GetEntry(repo);
+        const request = {id};
+
+        // Act
+        const response = await uc.execute(request);
+
+        // Assert
+        expect(response.success).toBe(false);
+        expect(response.status).toBe(404);
+        expect(response).toHaveProperty('code', 'ENTRY_NOT_FOUND');
+
+        expect(findByIdMock).toHaveBeenCalledTimes(1);
+        expect(findByIdMock).toHaveBeenCalledWith(id);
+    });
+});

--- a/frontend/tests/Unit/Application/UseCases/Entries/ListEntries/AC01_HappyPath.test.ts
+++ b/frontend/tests/Unit/Application/UseCases/Entries/ListEntries/AC01_HappyPath.test.ts
@@ -20,6 +20,7 @@ import {ListEntriesCriteriaFactory} from '@src/Application/Factories/ListEntries
 
 import {ac01HappyPath as makeRequest} from '@tests/helpers/http/requests/entries/ListEntriesRequestFactory';
 import {EntryFactory} from '@tests/helpers/domain/entries/EntryFactory';
+import {ensureSuccess} from '@tests/helpers/asserts';
 
 describe('AC01 — ListEntries (Application) returns success=true and page', () => {
     let repo: EntryRepositoryInterface;
@@ -58,11 +59,12 @@ describe('AC01 — ListEntries (Application) returns success=true and page', () 
 
         // Act
         const response = await uc.execute(request);
+        const okResponse = ensureSuccess(response);
 
         // Assert
-        expect(response.success).toBe(true);
-        expect(response.status).toBe(200);
-        expect(response.data).toEqual(page);
+        expect(okResponse.success).toBe(true);
+        expect(okResponse.status).toBe(200);
+        expect(okResponse.data).toEqual(page);
 
         expect(listMock).toHaveBeenCalledTimes(1);
         expect(listMock).toHaveBeenCalledWith(criteria);


### PR DESCRIPTION
Implements the Application-level use case for UC-3 Get Entry.
Bridges DTOs with EntryRepository.findById and returns typed UseCaseResponse.
Includes unit tests for both success (200) and not-found (404) branches.

Resolve #43