### PR TITLE
test(presentation): add AC02–AC04 negative tests for UseCaseRunner

### DIFF
--- a/frontend/tests/Unit/Presentation/UseCaseRunner/AC02_NotFound404.test.ts
+++ b/frontend/tests/Unit/Presentation/UseCaseRunner/AC02_NotFound404.test.ts
@@ -1,0 +1,80 @@
+// frontend/tests/Unit/Presentation/UseCaseRunner/AC02_NotFound404.test.ts
+import {describe, it, expect, vi} from 'vitest';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+
+/**
+ * AC-02 — NotFound (404) → normalized error envelope.
+ *
+ * Purpose:
+ * Verify that UseCaseRunner.run() maps a rejected use case with status 404
+ * into a UI-friendly error envelope with code ENTRY_NOT_FOUND.
+ *
+ * Mechanics:
+ * - Arrange:
+ *   - Define fake request DTO.
+ *   - Build fake use case whose execute(req) throws an error object with { status:404 }.
+ *   - Spy on execute to confirm it was called once with the same request.
+ * - Act:
+ *   - Call UseCaseRunner.run(fakeUseCase, fakeRequest).
+ * - Assert:
+ *   - success === false
+ *   - status === 404
+ *   - code === 'ENTRY_NOT_FOUND'
+ *   - execute called exactly once with fakeRequest.
+ *
+ * Cases:
+ * - AC02: First error scenario — 404 Not Found mapped to ENTRY_NOT_FOUND.
+ *
+ * @covers UseCaseRunner.run
+ */
+describe('UseCaseRunner — AC02_NotFound404', () => {
+    it('maps status 404 to {success:false, status:404, code:"ENTRY_NOT_FOUND"}', async () => {
+        // Arrange
+        type FakeRequestDto = {id: string};
+        type FakeDataDto = unknown;
+
+        const fakeRequest: FakeRequestDto = {
+            id: '00000000-0000-0000-0000-000000000000'
+        };
+
+        const fakeExecute = vi.fn(async (req: FakeRequestDto) => {
+            void req;
+
+            const error = {
+                status: 404
+            };
+
+            throw error;
+        });
+
+        const fakeUseCase = {
+            /**
+             * Fake Application use case used only to simulate 404 rejection.
+             */
+            execute: fakeExecute
+        };
+
+        // Act
+        const envelope = await UseCaseRunner.run<FakeRequestDto, FakeDataDto>(
+            fakeUseCase,
+            fakeRequest
+        );
+
+        // Assert (atomic, no derived expressions inside expect)
+        const callsCount = fakeExecute.mock.calls.length;
+        expect(callsCount).toBe(1);
+
+        const firstCallArgs = fakeExecute.mock.calls[0];
+        const calledWith = firstCallArgs[0];
+        expect(calledWith).toBe(fakeRequest);
+
+        const isSuccess = envelope.success;
+        expect(isSuccess).toBe(false);
+
+        const status = envelope.status;
+        expect(status).toBe(404);
+
+        const code = envelope.code;
+        expect(code).toBe('ENTRY_NOT_FOUND');
+    });
+});

--- a/frontend/tests/Unit/Presentation/UseCaseRunner/AC03_Validation422.test.ts
+++ b/frontend/tests/Unit/Presentation/UseCaseRunner/AC03_Validation422.test.ts
@@ -1,0 +1,86 @@
+// frontend/tests/Unit/Presentation/UseCaseRunner/AC03_Validation422.test.ts
+import {describe, it, expect, vi} from 'vitest';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+
+/**
+ * AC-03 — Validation (422) → normalized error envelope.
+ *
+ * Purpose:
+ * Verify that UseCaseRunner.run() maps a rejected use case with status 422
+ * into a UI-friendly error envelope with code VALIDATION_ERROR and
+ * preserves the errors object.
+ *
+ * Mechanics:
+ * - Arrange:
+ *   - Fake request DTO.
+ *   - Fake use case whose execute(req) throws { status:422, errors:{...} }.
+ *   - Spy to confirm execute was called once with the same request.
+ * - Act:
+ *   - Call UseCaseRunner.run(fakeUseCase, fakeRequest).
+ * - Assert:
+ *   - success === false
+ *   - status === 422
+ *   - code === 'VALIDATION_ERROR'
+ *   - errors are preserved
+ *   - execute called exactly once
+ *
+ * Cases:
+ * - AC03: Validation error mapping.
+ *
+ * @covers UseCaseRunner.run
+ */
+describe('UseCaseRunner — AC03_Validation422', () => {
+    it('maps status 422 to VALIDATION_ERROR and preserves errors', async () => {
+        // Arrange
+        type FakeRequestDto = {title: string};
+        type FakeDataDto = unknown;
+
+        const fakeRequest: FakeRequestDto = {title: ''};
+
+        const validationErrors = {
+            TITLE_REQUIRED: true,
+            BODY_TOO_LONG: false
+        };
+
+        const fakeExecute = vi.fn(async (req: FakeRequestDto) => {
+            void req;
+
+            const error = {
+                status: 422,
+                errors: validationErrors
+            };
+
+            throw error;
+        });
+
+        const fakeUseCase = {
+            execute: fakeExecute
+        };
+
+        // Act
+        const envelope = await UseCaseRunner.run<FakeRequestDto, FakeDataDto>(
+            fakeUseCase,
+            fakeRequest
+        );
+
+        // Assert (atomic)
+        const callsCount = fakeExecute.mock.calls.length;
+        expect(callsCount).toBe(1);
+
+        const firstCallArgs = fakeExecute.mock.calls[0];
+        const calledWith = firstCallArgs[0];
+        expect(calledWith).toBe(fakeRequest);
+
+        const isSuccess = envelope.success;
+        expect(isSuccess).toBe(false);
+
+        const status = envelope.status;
+        expect(status).toBe(422);
+
+        const code = envelope.code;
+        expect(code).toBe('VALIDATION_ERROR');
+
+        const errors = envelope.errors;
+        expect(errors).toBe(validationErrors);
+    });
+});

--- a/frontend/tests/Unit/Presentation/UseCaseRunner/AC04_Unexpected500.test.ts
+++ b/frontend/tests/Unit/Presentation/UseCaseRunner/AC04_Unexpected500.test.ts
@@ -1,0 +1,74 @@
+// frontend/tests/Unit/Presentation/UseCaseRunner/AC04_Unexpected500.test.ts
+import {describe, it, expect, vi} from 'vitest';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+
+/**
+ * AC-04 — Unexpected (500) → normalized error envelope.
+ *
+ * Purpose:
+ * Verify that UseCaseRunner.run() maps unexpected or unclassified errors
+ * (status >= 500 or missing code) into a generic UNKNOWN_ERROR envelope.
+ *
+ * Mechanics:
+ * - Arrange:
+ *   - Fake request DTO.
+ *   - Fake use case whose execute(req) throws { status:500 } without a code.
+ *   - Spy to confirm execute was called once.
+ * - Act:
+ *   - Call UseCaseRunner.run(fakeUseCase, fakeRequest).
+ * - Assert:
+ *   - success === false
+ *   - status === 500
+ *   - code === 'UNKNOWN_ERROR'
+ *
+ * Cases:
+ * - AC04: Unexpected error (fallback branch).
+ *
+ * @covers UseCaseRunner.run
+ */
+describe('UseCaseRunner — AC04_Unexpected500', () => {
+    it('maps status 500 to UNKNOWN_ERROR', async () => {
+        // Arrange
+        type FakeRequestDto = {op: string};
+        type FakeDataDto = unknown;
+
+        const fakeRequest: FakeRequestDto = {op: 'test'};
+
+        const fakeExecute = vi.fn(async (req: FakeRequestDto) => {
+            void req;
+
+            const error = {
+                status: 500
+            };
+
+            throw error;
+        });
+
+        const fakeUseCase = {
+            execute: fakeExecute
+        };
+
+        // Act
+        const envelope = await UseCaseRunner.run<FakeRequestDto, FakeDataDto>(
+            fakeUseCase,
+            fakeRequest
+        );
+
+        // Assert (atomic)
+        const callsCount = fakeExecute.mock.calls.length;
+        expect(callsCount).toBe(1);
+
+        const firstCallArgs = fakeExecute.mock.calls[0];
+        const calledWith = firstCallArgs[0];
+        expect(calledWith).toBe(fakeRequest);
+
+        const isSuccess = envelope.success;
+        expect(isSuccess).toBe(false);
+
+        const status = envelope.status;
+        expect(status).toBe(500);
+
+        const code = envelope.code;
+        expect(code).toBe('UNKNOWN_ERROR');
+    });
+});


### PR DESCRIPTION
Add negative tests AC02–AC04 for UseCaseRunner.

This PR completes the error-path coverage for the Presentation-level runner:
- AC02: maps 404 → ENTRY_NOT_FOUND
- AC03: maps 422 → VALIDATION_ERROR (with errors)
- AC04: maps 500 → UNKNOWN_ERROR

All tests follow the project conventions (no chained assertions, extended JSDoc).
No changes to production code were required.

Resolve #51