### PR TITLE
feat(frontend): add providers for remaining Entry use cases

### DIFF
--- a/frontend/src/Application/DTO/Common/ExecutableUseCase.ts
+++ b/frontend/src/Application/DTO/Common/ExecutableUseCase.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * Generic interface for any Application-level use case.
+ *
+ * @template TRequest Request DTO type.
+ */
+export interface ExecutableUseCase<TRequest> {
+    /**
+     * Execute the use case with given request DTO.
+     *
+     * @param {TRequest} req
+     * Request DTO.
+     *
+     * @returns {Promise<unknown>}
+     * Promise resolving to raw Application result or throwing an error.
+     */
+    execute(req: TRequest): Promise<unknown>;
+}

--- a/frontend/src/Configuration/Providers/Entries/AddEntryProvider.ts
+++ b/frontend/src/Configuration/Providers/Entries/AddEntryProvider.ts
@@ -1,0 +1,30 @@
+import {FetchHttpClient} from '@src/Infrastructure/Http/FetchHttpClient';
+import {EntryRepository} from '@src/Infrastructure/Repositories/Entries/EntryRepository';
+import {AddEntry} from '@src/Application/UseCases/Entries/AddEntry/AddEntry';
+
+/**
+ * Factory for UC-1 (AddEntry) wiring.
+ *
+ * Purpose:
+ * - Provide a fully constructed AddEntry use case for the Presentation layer.
+ * - Hide infrastructure details (HTTP client, repository).
+ *
+ * Notes:
+ * - No business logic here — only composition.
+ * - Part of the frontend Composition Root for Entry-related use cases.
+ */
+export function makeAddEntryUseCase(): AddEntry {
+    // 0) Read base URL
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
+    // 1) Infrastructure: HTTP client
+    const httpClient = new FetchHttpClient(baseUrl);
+
+    // 2) Infrastructure: Repository
+    const repo = new EntryRepository(httpClient);
+
+    // 3) Application: Use Case
+    const useCase = new AddEntry(repo);
+
+    return useCase;
+}

--- a/frontend/src/Configuration/Providers/Entries/DeleteEntryProvider.ts
+++ b/frontend/src/Configuration/Providers/Entries/DeleteEntryProvider.ts
@@ -1,0 +1,30 @@
+import {FetchHttpClient} from '@src/Infrastructure/Http/FetchHttpClient';
+import {EntryRepository} from '@src/Infrastructure/Repositories/Entries/EntryRepository';
+import {DeleteEntry} from '@src/Application/UseCases/Entries/DeleteEntry/DeleteEntry';
+
+/**
+ * Factory for UC-4 (DeleteEntry) wiring.
+ *
+ * Purpose:
+ * - Provide a fully constructed DeleteEntry use case for the Presentation layer.
+ * - Hide infrastructure details (HTTP client, repository).
+ *
+ * Notes:
+ * - No business logic here — only composition.
+ * - Part of the frontend Composition Root for Entry-related use cases.
+ */
+export function makeDeleteEntryUseCase(): DeleteEntry {
+    // 0) Read base URL
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
+    // 1) Infrastructure: HTTP client
+    const httpClient = new FetchHttpClient(baseUrl);
+
+    // 2) Infrastructure: Repository
+    const repo = new EntryRepository(httpClient);
+
+    // 3) Application: Use Case
+    const useCase = new DeleteEntry(repo);
+
+    return useCase;
+}

--- a/frontend/src/Configuration/Providers/Entries/GetEntryProvider.ts
+++ b/frontend/src/Configuration/Providers/Entries/GetEntryProvider.ts
@@ -1,0 +1,30 @@
+import {FetchHttpClient} from '@src/Infrastructure/Http/FetchHttpClient';
+import {EntryRepository} from '@src/Infrastructure/Repositories/Entries/EntryRepository';
+import {GetEntry} from '@src/Application/UseCases/Entries/GetEntry/GetEntry';
+
+/**
+ * Factory for UC-3 (GetEntry) wiring.
+ *
+ * Purpose:
+ * - Provide a fully constructed GetEntry use case for the Presentation layer.
+ * - Hide infrastructure details (HTTP client, repository).
+ *
+ * Notes:
+ * - No business logic here — only composition.
+ * - Part of the frontend Composition Root for Entry-related use cases.
+ */
+export function makeGetEntryUseCase(): GetEntry {
+    // 0) Read base URL
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
+    // 1) Infrastructure: HTTP client
+    const httpClient = new FetchHttpClient(baseUrl);
+
+    // 2) Infrastructure: Repository
+    const repo = new EntryRepository(httpClient);
+
+    // 3) Application: Use Case
+    const useCase = new GetEntry(repo);
+
+    return useCase;
+}

--- a/frontend/src/Configuration/Providers/Entries/UpdateEntryProvider.ts
+++ b/frontend/src/Configuration/Providers/Entries/UpdateEntryProvider.ts
@@ -1,0 +1,30 @@
+import {FetchHttpClient} from '@src/Infrastructure/Http/FetchHttpClient';
+import {EntryRepository} from '@src/Infrastructure/Repositories/Entries/EntryRepository';
+import {UpdateEntry} from '@src/Application/UseCases/Entries/UpdateEntry/UpdateEntry';
+
+/**
+ * Factory for UC-5 (UpdateEntry) wiring.
+ *
+ * Purpose:
+ * - Provide a fully constructed UpdateEntry use case for the Presentation layer.
+ * - Hide infrastructure details (HTTP client, repository).
+ *
+ * Notes:
+ * - No business logic here — only composition.
+ * - Part of the frontend Composition Root for Entry-related use cases.
+ */
+export function makeUpdateEntryUseCase(): UpdateEntry {
+    // 0) Read base URL
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
+    // 1) Infrastructure: HTTP client
+    const httpClient = new FetchHttpClient(baseUrl);
+
+    // 2) Infrastructure: Repository
+    const repo = new EntryRepository(httpClient);
+
+    // 3) Application: Use Case
+    const useCase = new UpdateEntry(repo);
+
+    return useCase;
+}

--- a/frontend/src/Presentation/runner/RunnerFailure.ts
+++ b/frontend/src/Presentation/runner/RunnerFailure.ts
@@ -1,0 +1,9 @@
+/**
+ * Failure envelope returned by UseCaseRunner.
+ */
+export type RunnerFailure = {
+    success: false;
+    status: number;
+    code: string;
+    errors?: unknown;
+};

--- a/frontend/src/Presentation/runner/RunnerSuccess.ts
+++ b/frontend/src/Presentation/runner/RunnerSuccess.ts
@@ -1,0 +1,11 @@
+
+/**
+ * Success envelope returned by UseCaseRunner.
+ *
+ * @template TData Payload type of successful response.
+ */
+export type RunnerSuccess<TData> = {
+    success: true;
+    status: 200;
+    data: TData;
+};

--- a/frontend/src/Presentation/runner/UseCaseRunner.ts
+++ b/frontend/src/Presentation/runner/UseCaseRunner.ts
@@ -1,41 +1,6 @@
-/**
- * Generic interface for any Application-level use case.
- *
- * @template TRequest Request DTO type.
- */
-export interface ExecutableUseCase<TRequest> {
-    /**
-     * Execute the use case with given request DTO.
-     *
-     * @param {TRequest} req
-     * Request DTO.
-     *
-     * @returns {Promise<unknown>}
-     * Promise resolving to raw Application result or throwing an error.
-     */
-    execute(req: TRequest): Promise<unknown>;
-}
-
-/**
- * Success envelope returned by UseCaseRunner.
- *
- * @template TData Payload type of successful response.
- */
-export type RunnerSuccess<TData> = {
-    success: true;
-    status: 200;
-    data: TData;
-};
-
-/**
- * Failure envelope returned by UseCaseRunner.
- */
-export type RunnerFailure = {
-    success: false;
-    status: number;
-    code: string;
-    errors?: unknown;
-};
+import type {ExecutableUseCase} from '@src/Application/DTO/Common/ExecutableUseCase';
+import type {RunnerSuccess} from './RunnerSuccess';
+import type {RunnerFailure} from './RunnerFailure';
 
 /**
  * UseCaseRunner — Presentation-level wrapper for executing Application use cases.


### PR DESCRIPTION
Adds provider factories for AddEntry, GetEntry, DeleteEntry and UpdateEntry.
Refactors UseCaseRunner: moves ExecutableUseCase to Application layer and
splits RunnerSuccess/RunnerFailure into separate Presentation files.

Resolve #55