### PR TITLE
feat(frontend): add vanilla ListEntries Web Component and stable <dl-list-entries> entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist/
 
 /backend/logs/*
 !/backend/logs/.gitkeep
+
+# Assets
+public/assets

--- a/backend/config/config.ini
+++ b/backend/config/config.ini
@@ -1,10 +1,10 @@
 [globals]
-                                   
+
 ;Common constants
 DEBUG    = 3
-;UI      = ../../frontend/src/
-AUTOLOAD = ../backend/src
-TEMP     = ../backend/tmp
+UI       = ../backend/src/Presentation/Templates/
+AUTOLOAD = ../backend/src/
+TEMP     = ../backend/tmp/
 SITE     = http://daylog.localhost
 
 ;Development constants

--- a/backend/src/Presentation/Controllers/Entries/Page/EntriesListPageController.php
+++ b/backend/src/Presentation/Controllers/Entries/Page/EntriesListPageController.php
@@ -18,8 +18,8 @@ final class EntriesListPageController extends BaseController
     public function show(): void
     {
         $data = [
-            'template' => 'list.html',
-            'script'   => 'list.js',
+            'template' => 'entries-list.html',
+            'script'   => 'entries-list-vanilla.js',
         ];
 
         $payload = ResponsePayload::success()

--- a/backend/src/Presentation/Templates/layouts/base.html
+++ b/backend/src/Presentation/Templates/layouts/base.html
@@ -6,7 +6,7 @@
     <title>{{ @pageTitle }}</title>
 
     <!-- Глобальные стили сайта -->
-    <link rel="stylesheet" href="/assets/css/style.css">
+    {**<link rel="stylesheet" href="/assets/css/style.css">**}
 </head>
 <body>
 

--- a/backend/src/Presentation/Templates/layouts/base.html
+++ b/backend/src/Presentation/Templates/layouts/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+
+    <title>{{ @pageTitle }}</title>
+
+    <!-- Глобальные стили сайта -->
+    <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+
+    <main>
+        <!-- Вставка конкретной страницы -->
+        <include href="{{ @contentTemplate }}" />
+    </main>
+
+    <!-- Page-specific scripts (optional) -->
+    {{ @pageScripts | raw }}
+
+</body>
+</html>

--- a/backend/src/Presentation/Templates/pages/entries-list.html
+++ b/backend/src/Presentation/Templates/pages/entries-list.html
@@ -1,0 +1,3 @@
+<h1>Daylog &ndash; UC-2: List Entries</h1>
+
+<dl-list-entries></dl-list-entries>

--- a/backend/src/Presentation/Views/Renderers/HtmlView.php
+++ b/backend/src/Presentation/Views/Renderers/HtmlView.php
@@ -4,37 +4,91 @@ declare(strict_types=1);
 namespace Daylog\Presentation\Views\Renderers;
 
 use Base;
+use RuntimeException;
 use Template;
 
 /**
- * HtmlView handles rendering HTML templates.
+ * HtmlView handles rendering HTML templates using F3 Template engine.
+ *
+ * Responsibilities:
+ * - Set appropriate Content-Type header for HTML responses.
+ * - Map generic response payload into F3 hive variables (pageTitle, contentTemplate, pageScripts).
+ * - Delegate final rendering to a layout template (layouts/base.html).
+ *
+ * Expected payload shape:
+ * - $payload['data']['template']: string      // content template path, e.g. "pages/entries-list.html"
+ * - $payload['data']['pageTitle']: string    // HTML <title> and H1 title
+ * - $payload['data']['script']?: string      // optional JS bundle path, e.g. "/assets/js/listEntriesVanilla.js"
  */
 final class HtmlView extends BaseView
 {
+    /**
+     * Get default Content-Type header value for HTML responses.
+     *
+     * @return string Content-Type for HTML output.
+     */
     protected function getDefaultContentType(): string
     {
-        return 'text/html; charset=UTF-8';
+        $contentType = 'text/html; charset=UTF-8';
+
+        return $contentType;
     }
 
     /**
      * Render response data into an HTML template.
      *
-     * @param array<string,mixed> $payload
-     * @return string
+     * The method:
+     * - applies HTTP headers via BaseView::setHeaders();
+     * - extracts template parameters from $payload['data'];
+     * - populates F3 hive variables used by layouts/base.html;
+     * - renders the base layout and returns the final HTML string.
+     *
+     * @param array<string,mixed> $payload Normalized response payload array.
+     *
+     * @return string Rendered HTML.
+     *
+     * @throws RuntimeException When required keys are missing in payload data.
      */
     public function render(array $payload): string
     {
         $this->setHeaders($payload);
 
-        $data = $payload['data'];
-        
-        $template = $data['template'];
-        $script   = $data['script'];
+        /** @var array<string,mixed> $data */
+        $data = [];
 
-        //Base::instance()->mset([]);
-        //$html = Template::instance()->render($template);
+        if (array_key_exists('data', $payload) && is_array($payload['data'])) {
+            /** @var array<string,mixed> $rawData */
+            $rawData = $payload['data'];
+            $data    = $rawData;
+        }
 
-        $html = sprintf('%s - %s', $template, $script);
+        if (!array_key_exists('template', $data) || !is_string($data['template'])) {
+            $message = 'HtmlView expects "template" key in payload data.';
+            throw new RuntimeException($message);
+        }
+
+        $template = sprintf('pages/%s', $data['template']);
+
+        $pageTitle = 'Daylog';
+        if (array_key_exists('pageTitle', $data) && is_string($data['pageTitle'])) {
+            $pageTitle = $data['pageTitle'];
+        }
+
+        $pageScripts = '';
+        if (array_key_exists('script', $data) && is_string($data['script'])) {
+            $scriptSrc   = $data['script'];
+            $pageScripts = sprintf('<script type="module" src="/assets/js/%s"></script>', $scriptSrc);
+        }
+
+        $f3 = Base::instance();
+        $f3->set('pageTitle', $pageTitle);
+        $f3->set('contentTemplate', $template);
+        $f3->set('pageScripts', $pageScripts);
+
+        $layoutPath     = 'layouts/base.html';
+        $templateEngine = Template::instance();
+        $html           = $templateEngine->render($layoutPath);
+
         return $html;
     }
 }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,6 @@
+# assets
+public/assets
+
 # Logs
 logs
 *.log

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,6 +1,3 @@
-# assets
-public/assets
-
 # Logs
 logs
 *.log

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
                 "husky": "^9.1.7",
                 "jsdom": "^27.0.0",
                 "prettier": "^3.6.2",
+                "sass-embedded": "^1.93.3",
                 "typescript": "~5.8.3",
                 "vite": "^7.1.7",
                 "vite-tsconfig-paths": "^5.1.4",
@@ -56,6 +57,13 @@
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@bufbuild/protobuf": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.1.tgz",
+            "integrity": "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg==",
+            "dev": true,
+            "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
         "node_modules/@csstools/color-helpers": {
             "version": "5.1.0",
@@ -920,6 +928,316 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@parcel/watcher": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+            "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "detect-libc": "^1.0.3",
+                "is-glob": "^4.0.3",
+                "micromatch": "^4.0.5",
+                "node-addon-api": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.5.1",
+                "@parcel/watcher-darwin-arm64": "2.5.1",
+                "@parcel/watcher-darwin-x64": "2.5.1",
+                "@parcel/watcher-freebsd-x64": "2.5.1",
+                "@parcel/watcher-linux-arm-glibc": "2.5.1",
+                "@parcel/watcher-linux-arm-musl": "2.5.1",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+                "@parcel/watcher-linux-arm64-musl": "2.5.1",
+                "@parcel/watcher-linux-x64-glibc": "2.5.1",
+                "@parcel/watcher-linux-x64-musl": "2.5.1",
+                "@parcel/watcher-win32-arm64": "2.5.1",
+                "@parcel/watcher-win32-ia32": "2.5.1",
+                "@parcel/watcher-win32-x64": "2.5.1"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+            "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+            "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+            "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+            "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+            "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+            "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+            "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+            "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+            "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+            "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+            "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+            "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+            "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1745,6 +2063,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/buffer-builder": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+            "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
+            "dev": true,
+            "license": "MIT/X11"
+        },
         "node_modules/cac": {
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1809,6 +2134,23 @@
                 "node": ">= 16"
             }
         },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1826,6 +2168,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/colorjs.io": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+            "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1935,6 +2284,20 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "bin": {
+                "detect-libc": "bin/detect-libc.js"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
         },
         "node_modules/entities": {
             "version": "6.0.1",
@@ -2588,6 +2951,13 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immutable": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+            "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2910,6 +3280,14 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3142,6 +3520,21 @@
             ],
             "license": "MIT"
         },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3246,12 +3639,409 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/sass": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.3.tgz",
+            "integrity": "sha512-elOcIZRTM76dvxNAjqYrucTSI0teAF/L2Lv0s6f6b7FOwcwIuA357bIE871580AjHJuSvLIRUosgV+lIWx6Rgg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "chokidar": "^4.0.0",
+                "immutable": "^5.0.2",
+                "source-map-js": ">=0.6.2 <2.0.0"
+            },
+            "bin": {
+                "sass": "sass.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher": "^2.4.1"
+            }
+        },
+        "node_modules/sass-embedded": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.93.3.tgz",
+            "integrity": "sha512-+VUy01yfDqNmIVMd/LLKl2TTtY0ovZN0rTonh+FhKr65mFwIYgU9WzgIZKS7U9/SPCQvWTsTGx9jyt+qRm/XFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bufbuild/protobuf": "^2.5.0",
+                "buffer-builder": "^0.2.0",
+                "colorjs.io": "^0.5.0",
+                "immutable": "^5.0.2",
+                "rxjs": "^7.4.0",
+                "supports-color": "^8.1.1",
+                "sync-child-process": "^1.0.2",
+                "varint": "^6.0.0"
+            },
+            "bin": {
+                "sass": "dist/bin/sass.js"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "optionalDependencies": {
+                "sass-embedded-all-unknown": "1.93.3",
+                "sass-embedded-android-arm": "1.93.3",
+                "sass-embedded-android-arm64": "1.93.3",
+                "sass-embedded-android-riscv64": "1.93.3",
+                "sass-embedded-android-x64": "1.93.3",
+                "sass-embedded-darwin-arm64": "1.93.3",
+                "sass-embedded-darwin-x64": "1.93.3",
+                "sass-embedded-linux-arm": "1.93.3",
+                "sass-embedded-linux-arm64": "1.93.3",
+                "sass-embedded-linux-musl-arm": "1.93.3",
+                "sass-embedded-linux-musl-arm64": "1.93.3",
+                "sass-embedded-linux-musl-riscv64": "1.93.3",
+                "sass-embedded-linux-musl-x64": "1.93.3",
+                "sass-embedded-linux-riscv64": "1.93.3",
+                "sass-embedded-linux-x64": "1.93.3",
+                "sass-embedded-unknown-all": "1.93.3",
+                "sass-embedded-win32-arm64": "1.93.3",
+                "sass-embedded-win32-x64": "1.93.3"
+            }
+        },
+        "node_modules/sass-embedded-all-unknown": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.93.3.tgz",
+            "integrity": "sha512-3okGgnE41eg+CPLtAPletu6nQ4N0ij7AeW+Sl5Km4j29XcmqZQeFwYjHe1AlKTEgLi/UAONk1O8i8/lupeKMbw==",
+            "cpu": [
+                "!arm",
+                "!arm64",
+                "!riscv64",
+                "!x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "sass": "1.93.3"
+            }
+        },
+        "node_modules/sass-embedded-android-arm": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.93.3.tgz",
+            "integrity": "sha512-8xOw9bywfOD6Wv24BgCmgjkk6tMrsOTTHcb28KDxeJtFtoxiUyMbxo0vChpPAfp2Hyg2tFFKS60s0s4JYk+Raw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-arm64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.93.3.tgz",
+            "integrity": "sha512-uqUl3Kt1IqdGVAcAdbmC+NwuUJy8tM+2ZnB7/zrt6WxWVShVCRdFnWR9LT8HJr7eJN7AU8kSXxaVX/gedanPsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-riscv64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.93.3.tgz",
+            "integrity": "sha512-2jNJDmo+3qLocjWqYbXiBDnfgwrUeZgZFHJIwAefU7Fn66Ot7rsXl+XPwlokaCbTpj7eMFIqsRAZ/uDueXNCJg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-x64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.93.3.tgz",
+            "integrity": "sha512-y0RoAU6ZenQFcjM9PjQd3cRqRTjqwSbtWLL/p68y2oFyh0QGN0+LQ826fc0ZvU/AbqCsAizkqjzOn6cRZJxTTQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-darwin-arm64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.93.3.tgz",
+            "integrity": "sha512-7zb/hpdMOdKteK17BOyyypemglVURd1Hdz6QGsggy60aUFfptTLQftLRg8r/xh1RbQAUKWFbYTNaM47J9yPxYg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-darwin-x64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.93.3.tgz",
+            "integrity": "sha512-Ek1Vp8ZDQEe327Lz0b7h3hjvWH3u9XjJiQzveq74RPpJQ2q6d9LfWpjiRRohM4qK6o4XOHw1X10OMWPXJtdtWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-arm": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.93.3.tgz",
+            "integrity": "sha512-yeiv2y+dp8B4wNpd3+JsHYD0mvpXSfov7IGyQ1tMIR40qv+ROkRqYiqQvAOXf76Qwh4Y9OaYZtLpnsPjfeq6mA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-arm64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.93.3.tgz",
+            "integrity": "sha512-RBrHWgfd8Dd8w4fbmdRVXRrhh8oBAPyeWDTKAWw8ZEmuXfVl4ytjDuyxaVilh6rR1xTRTNpbaA/YWApBlLrrNw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-arm": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.93.3.tgz",
+            "integrity": "sha512-fU0fwAwbp7sBE3h5DVU5UPzvaLg7a4yONfFWkkcCp6ZrOiPuGRHXXYriWQ0TUnWy4wE+svsVuWhwWgvlb/tkKg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-arm64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.93.3.tgz",
+            "integrity": "sha512-PS829l+eUng+9W4PFclXGb4uA2+965NHV3/Sa5U7qTywjeeUUYTZg70dJHSqvhrBEfCc2XJABeW3adLJbyQYkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-riscv64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.93.3.tgz",
+            "integrity": "sha512-cK1oBY+FWQquaIGEeQ5H74KTO8cWsSWwXb/WaildOO9U6wmUypTgUYKQ0o5o/29nZbWWlM1PHuwVYTSnT23Jjg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-x64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.93.3.tgz",
+            "integrity": "sha512-A7wkrsHu2/I4Zpa0NMuPGkWDVV7QGGytxGyUq3opSXgAexHo/vBPlGoDXoRlSdex0cV+aTMRPjoGIfdmNlHwyg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-riscv64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.93.3.tgz",
+            "integrity": "sha512-vWkW1+HTF5qcaHa6hO80gx/QfB6GGjJUP0xLbnAoY4pwEnw5ulGv6RM8qYr8IDhWfVt/KH+lhJ2ZFxnJareisQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-x64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.93.3.tgz",
+            "integrity": "sha512-k6uFxs+e5jSuk1Y0niCwuq42F9ZC5UEP7P+RIOurIm8w/5QFa0+YqeW+BPWEW5M1FqVOsNZH3qGn4ahqvAEjPA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-unknown-all": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.93.3.tgz",
+            "integrity": "sha512-o5wj2rLpXH0C+GJKt/VpWp6AnMsCCbfFmnMAttcrsa+U3yrs/guhZ3x55KAqqUsE8F47e3frbsDL+1OuQM5DAA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "!android",
+                "!darwin",
+                "!linux",
+                "!win32"
+            ],
+            "dependencies": {
+                "sass": "1.93.3"
+            }
+        },
+        "node_modules/sass-embedded-win32-arm64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.93.3.tgz",
+            "integrity": "sha512-0dOfT9moy9YmBolodwYYXtLwNr4jL4HQC9rBfv6mVrD7ud8ue2kDbn+GVzj1hEJxvEexVSmDCf7MHUTLcGs9xQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-x64": {
+            "version": "1.93.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.93.3.tgz",
+            "integrity": "sha512-wHFVfxiS9hU/sNk7KReD+lJWRp3R0SLQEX4zfOnRP2zlvI2X4IQR5aZr9GNcuMP6TmNpX0nQPZTegS8+h9RrEg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
         },
         "node_modules/saxes": {
             "version": "6.0.0",
@@ -3378,6 +4168,29 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/sync-child-process": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+            "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sync-message-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/sync-message-port": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz",
+            "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/synckit": {
             "version": "0.11.11",
@@ -3549,6 +4362,13 @@
                 }
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3585,6 +4405,13 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vite": {
             "version": "7.1.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
         "husky": "^9.1.7",
         "jsdom": "^27.0.0",
         "prettier": "^3.6.2",
+        "sass-embedded": "^1.93.3",
         "typescript": "~5.8.3",
         "vite": "^7.1.7",
         "vite-tsconfig-paths": "^5.1.4",

--- a/frontend/src/Domain/Interfaces/Entries/ListEntriesCriteriaInterface.ts
+++ b/frontend/src/Domain/Interfaces/Entries/ListEntriesCriteriaInterface.ts
@@ -17,4 +17,6 @@ export interface ListEntriesCriteriaInterface {
     query?: string;
     dateFrom?: string;
     dateTo?: string;
+    sortField?: 'date' | 'createdAt' | 'updatedAt';
+    sortDir?: 'ASC' | 'DESC';
 }

--- a/frontend/src/Infrastructure/Http/Endpoints.ts
+++ b/frontend/src/Infrastructure/Http/Endpoints.ts
@@ -21,6 +21,6 @@
  */
 
 export const Endpoints = {
-    entries: () => '/api/entries',
-    entryById: (id: string) => `/api/entries/${id}`
+    entries: () => '/entries',
+    entryById: (id: string) => `/entries/${id}`
 };

--- a/frontend/src/Infrastructure/Repositories/Entries/EntryRepository.ts
+++ b/frontend/src/Infrastructure/Repositories/Entries/EntryRepository.ts
@@ -87,6 +87,14 @@ export class EntryRepository implements EntryRepositoryInterface {
             params.set('dateTo', criteria.dateTo);
         }
 
+        if (criteria.sortField) {
+            params.set('sortField', criteria.sortField);
+        }
+
+        if (criteria.sortDir) {
+            params.set('sortDir', criteria.sortDir);
+        }
+
         const baseUrl = Endpoints.entries();
         const query = params.toString();
         const url = `${baseUrl}?${query}`;

--- a/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
@@ -1,0 +1,255 @@
+/**
+ * Vanilla Web Component for UC-2 (ListEntries).
+ *
+ * Purpose:
+ * - Execute UC-2 via UseCaseRunner + ListEntries provider.
+ * - Render three visual states via shadow DOM:
+ *   loading, data, error.
+ *
+ * Notes:
+ * - The component depends only on application/domain-level abstractions:
+ *   UseCaseRunner, UseCaseResponse, ListEntriesPageInterface.
+ * - It does not know anything about HTTP or repositories.
+ */
+
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+import {makeListEntriesUseCase} from '@src/Configuration/Providers/Entries/ListEntriesProvider';
+
+/**
+ * Minimal runner interface used by the component.
+ * Real implementation is built from UseCaseRunner + ListEntries use case.
+ * Tests inject a fake implementation.
+ */
+export interface ListEntriesRunner {
+    run: () => Promise<UseCaseResponse<ListEntriesPageInterface>>;
+}
+
+/**
+ * Create ListEntriesRunner backed by UseCaseRunner and ListEntries use case provider.
+ *
+ * @returns {ListEntriesRunner} Runner that executes UC-2 ListEntries.
+ */
+function createListEntriesRunner(): ListEntriesRunner {
+    const useCase = makeListEntriesUseCase();
+
+    const listEntriesRunner: ListEntriesRunner = {
+        run: async (): Promise<UseCaseResponse<ListEntriesPageInterface>> => {
+            const params = {};
+
+            const runnerResult = await UseCaseRunner.run<typeof params, ListEntriesPageInterface>(
+                useCase,
+                params
+            );
+
+            const response = runnerResult as UseCaseResponse<ListEntriesPageInterface>;
+
+            return response;
+        }
+    };
+
+    return listEntriesRunner;
+}
+
+/**
+ * Web Component <dl-list-entries> for UC-2 ListEntries.
+ *
+ * Scenarios:
+ * - On connection, shows loading state and triggers UC-2.
+ * - On success, renders a list of entries.
+ * - On failure or exception, renders error message.
+ *
+ * The public contract is the custom element itself; internal wiring
+ * is hidden behind ListEntriesRunner.
+ */
+export class ListEntriesElement extends HTMLElement {
+    private readonly runner: ListEntriesRunner;
+
+    public constructor(runner?: ListEntriesRunner) {
+        super();
+
+        const shadow = this.attachShadow({mode: 'open'});
+
+        this.runner = runner ?? createListEntriesRunner();
+
+        this.renderLoading(shadow);
+    }
+
+    public connectedCallback(): void {
+        const shadow = this.shadowRoot as ShadowRoot;
+
+        void this.loadEntries(shadow);
+    }
+
+    /**
+     * Execute UC-2 and switch between loading/data/error states.
+     *
+     * @param {ShadowRoot} shadow Shadow root used for rendering.
+     *
+     * @returns {Promise<void>} Promise that resolves when rendering is complete.
+     */
+    private async loadEntries(shadow: ShadowRoot): Promise<void> {
+        this.renderLoading(shadow);
+
+        try {
+            const response = await this.runner.run();
+
+            if (response.success && response.data) {
+                this.renderData(shadow, response.data);
+
+                return;
+            }
+
+            const message = this.extractErrorMessage(response);
+            this.renderError(shadow, message);
+        } catch (error) {
+            const fallback = 'Failed to load entries. Please try again.';
+            this.renderError(shadow, fallback);
+        }
+    }
+
+    /**
+     * Extract the most relevant error message from UseCaseResponse.
+     *
+     * @param {UseCaseResponse<ListEntriesPageInterface>} response UC-2 response.
+     *
+     * @returns {string} Human-readable error message.
+     */
+    private extractErrorMessage(response: UseCaseResponse<ListEntriesPageInterface>): string {
+        if (Array.isArray(response.errors) && response.errors.length > 0) {
+            const message = response.errors[0];
+
+            return message;
+        }
+
+        const fallback = 'Failed to load entries. Please try again.';
+
+        return fallback;
+    }
+
+    /**
+     * Render loading state into shadow DOM.
+     *
+     * @param {ShadowRoot} shadow Shadow root for the component.
+     *
+     * @returns {void}
+     */
+    private renderLoading(shadow: ShadowRoot): void {
+        const html = `
+            <style>
+                :host {
+                    display: block;
+                    font-family: system-ui, -apple-system, BlinkMacSystemFont,
+                        "Segoe UI", sans-serif;
+                }
+
+                .dl-list-entries__loading {
+                    padding: 0.5rem 0;
+                    font-size: 0.9rem;
+                    opacity: 0.75;
+                }
+            </style>
+            <div class="dl-list-entries__loading" data-testid="loading">
+                Loading entries...
+            </div>
+        `;
+
+        shadow.innerHTML = html;
+    }
+
+    /**
+     * Render error state into shadow DOM.
+     *
+     * @param {ShadowRoot} shadow Shadow root for the component.
+     * @param {string} message Error message to show.
+     *
+     * @returns {void}
+     */
+    private renderError(shadow: ShadowRoot, message: string): void {
+        const html = `
+            <style>
+                :host {
+                    display: block;
+                    font-family: system-ui, -apple-system, BlinkMacSystemFont,
+                        "Segoe UI", sans-serif;
+                }
+
+                .dl-list-entries__error {
+                    padding: 0.5rem 0;
+                    font-size: 0.9rem;
+                    color: #b00020;
+                }
+            </style>
+            <div class="dl-list-entries__error" data-testid="error">
+                ${message}
+            </div>
+        `;
+
+        shadow.innerHTML = html;
+    }
+
+    /**
+     * Render list of entries into shadow DOM.
+     *
+     * @param {ShadowRoot} shadow Shadow root for the component.
+     * @param {ListEntriesPageInterface} page Page payload returned by UC-2.
+     *
+     * @returns {void}
+     */
+    private renderData(shadow: ShadowRoot, page: ListEntriesPageInterface): void {
+        const itemsHtml = page.items
+            .map((entry): string => {
+                const dateText = entry.date;
+
+                const itemHtml = `
+                    <li class="dl-list-entries__item" data-testid="entry-item">
+                        <h3 class="dl-list-entries__item-title">${entry.title}</h3>
+                        <p class="dl-list-entries__item-meta">
+                            <span>${dateText}</span>
+                        </p>
+                    </li>
+                `;
+
+                return itemHtml;
+            })
+            .join('');
+
+        const html = `
+            <style>
+                :host {
+                    display: block;
+                    font-family: system-ui, -apple-system, BlinkMacSystemFont,
+                        "Segoe UI", sans-serif;
+                }
+
+                .dl-list-entries__items {
+                    list-style: none;
+                    padding: 0;
+                    margin: 0.5rem 0 0;
+                }
+
+                .dl-list-entries__item {
+                    padding: 0.5rem 0;
+                    border-bottom: 1px solid #ddd;
+                }
+
+                .dl-list-entries__item-title {
+                    font-weight: 600;
+                    margin: 0 0 0.15rem;
+                }
+
+                .dl-list-entries__item-meta {
+                    font-size: 0.8rem;
+                    color: #555;
+                    margin: 0;
+                }
+            </style>
+            <ul class="dl-list-entries__items">
+                ${itemsHtml}
+            </ul>
+        `;
+
+        shadow.innerHTML = html;
+    }
+}

--- a/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
@@ -199,15 +199,25 @@ export class ListEntriesElement extends HTMLElement {
      */
     private renderData(shadow: ShadowRoot, page: ListEntriesPageInterface): void {
         const itemsHtml = page.items
-            .map((entry): string => {
-                const dateText = entry.date;
+            .map((entry, index): string => {
+                const baseIndex = (page.page - 1) * page.perPage;
+                const number = baseIndex + index + 1;
+
+                const numberText = `№ ${number}. ${entry.date}`;
+                const titleText = entry.title;
+                const bodyText = entry.body;
 
                 const itemHtml = `
                     <li class="dl-list-entries__item" data-testid="entry-item">
-                        <h3 class="dl-list-entries__item-title">${entry.title}</h3>
-                        <p class="dl-list-entries__item-meta">
-                            <span>${dateText}</span>
-                        </p>
+                        <div class="dl-list-entries__item-header">
+                            <span class="dl-list-entries__item-number">${numberText}</span>
+                            <button class="dl-list-entries__view-button" type="button">
+                                Просмотреть
+                            </button>
+                        </div>
+
+                        <p class="dl-list-entries__item-title">${titleText}</p>
+                        <p class="dl-list-entries__item-body">${bodyText}</p>
                     </li>
                 `;
 
@@ -230,19 +240,38 @@ export class ListEntriesElement extends HTMLElement {
                 }
 
                 .dl-list-entries__item {
-                    padding: 0.5rem 0;
+                    padding: 0.75rem 1rem;
                     border-bottom: 1px solid #ddd;
                 }
 
-                .dl-list-entries__item-title {
-                    font-weight: 600;
-                    margin: 0 0 0.15rem;
+                .dl-list-entries__item-header {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 0.5rem;
                 }
 
-                .dl-list-entries__item-meta {
-                    font-size: 0.8rem;
-                    color: #555;
+                .dl-list-entries__item-number {
+                    font-weight: 600;
+                }
+
+                .dl-list-entries__view-button {
+                    font-size: 0.85rem;
+                    padding: 0.25rem 0.75rem;
+                    border-radius: 4px;
+                    border: 1px solid #e0e0e0;
+                    background: #f5f5f5;
+                    cursor: pointer;
+                }
+
+                .dl-list-entries__item-title {
+                    margin: 0 0 0.25rem;
+                    font-weight: 500;
+                }
+
+                .dl-list-entries__item-body {
                     margin: 0;
+                    font-size: 0.9rem;
                 }
             </style>
             <ul class="dl-list-entries__items">
@@ -252,4 +281,5 @@ export class ListEntriesElement extends HTMLElement {
 
         shadow.innerHTML = html;
     }
+
 }

--- a/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
@@ -73,6 +73,7 @@ export class ListEntriesElement extends HTMLElement {
 
         this.runner = runner ?? createListEntriesRunner();
 
+        this.loadStyles(shadow);
         this.renderLoading(shadow);
     }
 
@@ -80,6 +81,16 @@ export class ListEntriesElement extends HTMLElement {
         const shadow = this.shadowRoot as ShadowRoot;
 
         void this.loadEntries(shadow);
+    }
+
+    private async loadStyles(shadow: ShadowRoot): Promise<void> {
+        const sheet = new CSSStyleSheet();
+        const cssUrl = '/assets/css/dl-list-entries.css';
+
+        const cssText = await fetch(cssUrl).then((r) => r.text());
+        await sheet.replace(cssText);
+
+        shadow.adoptedStyleSheets = [sheet];
     }
 
     /**
@@ -137,19 +148,6 @@ export class ListEntriesElement extends HTMLElement {
      */
     private renderLoading(shadow: ShadowRoot): void {
         const html = `
-            <style>
-                :host {
-                    display: block;
-                    font-family: system-ui, -apple-system, BlinkMacSystemFont,
-                        "Segoe UI", sans-serif;
-                }
-
-                .dl-list-entries__loading {
-                    padding: 0.5rem 0;
-                    font-size: 0.9rem;
-                    opacity: 0.75;
-                }
-            </style>
             <div class="dl-list-entries__loading" data-testid="loading">
                 Loading entries...
             </div>
@@ -168,19 +166,6 @@ export class ListEntriesElement extends HTMLElement {
      */
     private renderError(shadow: ShadowRoot, message: string): void {
         const html = `
-            <style>
-                :host {
-                    display: block;
-                    font-family: system-ui, -apple-system, BlinkMacSystemFont,
-                        "Segoe UI", sans-serif;
-                }
-
-                .dl-list-entries__error {
-                    padding: 0.5rem 0;
-                    font-size: 0.9rem;
-                    color: #b00020;
-                }
-            </style>
             <div class="dl-list-entries__error" data-testid="error">
                 ${message}
             </div>
@@ -226,54 +211,6 @@ export class ListEntriesElement extends HTMLElement {
             .join('');
 
         const html = `
-            <style>
-                :host {
-                    display: block;
-                    font-family: system-ui, -apple-system, BlinkMacSystemFont,
-                        "Segoe UI", sans-serif;
-                }
-
-                .dl-list-entries__items {
-                    list-style: none;
-                    padding: 0;
-                    margin: 0.5rem 0 0;
-                }
-
-                .dl-list-entries__item {
-                    padding: 0.75rem 1rem;
-                    border-bottom: 1px solid #ddd;
-                }
-
-                .dl-list-entries__item-header {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    margin-bottom: 0.5rem;
-                }
-
-                .dl-list-entries__item-number {
-                    font-weight: 600;
-                }
-
-                .dl-list-entries__view-button {
-                    font-size: 0.85rem;
-                    padding: 0.25rem 0.75rem;
-                    border-radius: 4px;
-                    border: 1px solid #e0e0e0;
-                    background: #f5f5f5;
-                    cursor: pointer;
-                }
-
-                .dl-list-entries__item-title {
-                    margin: 0 0 0.25rem;
-                    font-weight: 500;
-                }
-
-                .dl-list-entries__item-body {
-                    margin: 0;
-                    font-size: 0.9rem;
-                }
-            </style>
             <ul class="dl-list-entries__items">
                 ${itemsHtml}
             </ul>
@@ -281,5 +218,4 @@ export class ListEntriesElement extends HTMLElement {
 
         shadow.innerHTML = html;
     }
-
 }

--- a/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/ListEntriesElement.ts
@@ -14,43 +14,8 @@
 
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
-import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
-import {makeListEntriesUseCase} from '@src/Configuration/Providers/Entries/ListEntriesProvider';
-
-/**
- * Minimal runner interface used by the component.
- * Real implementation is built from UseCaseRunner + ListEntries use case.
- * Tests inject a fake implementation.
- */
-export interface ListEntriesRunner {
-    run: () => Promise<UseCaseResponse<ListEntriesPageInterface>>;
-}
-
-/**
- * Create ListEntriesRunner backed by UseCaseRunner and ListEntries use case provider.
- *
- * @returns {ListEntriesRunner} Runner that executes UC-2 ListEntries.
- */
-function createListEntriesRunner(): ListEntriesRunner {
-    const useCase = makeListEntriesUseCase();
-
-    const listEntriesRunner: ListEntriesRunner = {
-        run: async (): Promise<UseCaseResponse<ListEntriesPageInterface>> => {
-            const params = {};
-
-            const runnerResult = await UseCaseRunner.run<typeof params, ListEntriesPageInterface>(
-                useCase,
-                params
-            );
-
-            const response = runnerResult as UseCaseResponse<ListEntriesPageInterface>;
-
-            return response;
-        }
-    };
-
-    return listEntriesRunner;
-}
+import type {ListEntriesRunner} from './ListEntriesRunner';
+import {createListEntriesRunner} from './ListEntriesRunner';
 
 /**
  * Web Component <dl-list-entries> for UC-2 ListEntries.
@@ -115,6 +80,8 @@ export class ListEntriesElement extends HTMLElement {
             const message = this.extractErrorMessage(response);
             this.renderError(shadow, message);
         } catch (error) {
+            console.error('UC-2 ListEntries failed:', error);
+
             const fallback = 'Failed to load entries. Please try again.';
             this.renderError(shadow, fallback);
         }
@@ -149,7 +116,7 @@ export class ListEntriesElement extends HTMLElement {
     private renderLoading(shadow: ShadowRoot): void {
         const html = `
             <div class="dl-list-entries__loading" data-testid="loading">
-                Loading entries...
+                Loading entries&hellip;
             </div>
         `;
 
@@ -183,6 +150,17 @@ export class ListEntriesElement extends HTMLElement {
      * @returns {void}
      */
     private renderData(shadow: ShadowRoot, page: ListEntriesPageInterface): void {
+        if (!page.items.length) {
+            const html = `
+                <div class="dl-list-entries__empty" data-testid="empty">
+                    Записей не найдено.
+                </div>`;
+
+            shadow.innerHTML = html;
+
+            return;
+        }
+
         const itemsHtml = page.items
             .map((entry, index): string => {
                 const baseIndex = (page.page - 1) * page.perPage;

--- a/frontend/src/Presentation/entries/vanilla/ListEntriesRunner.ts
+++ b/frontend/src/Presentation/entries/vanilla/ListEntriesRunner.ts
@@ -1,0 +1,25 @@
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+import {makeListEntriesUseCase} from '@src/Configuration/Providers/Entries/ListEntriesProvider';
+
+export interface ListEntriesRunner {
+    run: () => Promise<UseCaseResponse<ListEntriesPageInterface>>;
+}
+
+export function createListEntriesRunner(): ListEntriesRunner {
+    const useCase = makeListEntriesUseCase();
+
+    const listEntriesRunner: ListEntriesRunner = {
+        run: async (): Promise<UseCaseResponse<ListEntriesPageInterface>> => {
+            const params = {};
+
+            const runnerResult = await UseCaseRunner.run(useCase, params);
+            const response = runnerResult as UseCaseResponse<ListEntriesPageInterface>;
+
+            return response;
+        }
+    };
+
+    return listEntriesRunner;
+}

--- a/frontend/src/Presentation/entries/vanilla/list.vanilla.entry.ts
+++ b/frontend/src/Presentation/entries/vanilla/list.vanilla.entry.ts
@@ -1,0 +1,34 @@
+/**
+ * Entry file for vanilla implementation of UC-2 (ListEntries).
+ *
+ * Purpose:
+ * - Register <dl-list-entries> custom element in the global registry.
+ * - Keep tag name stable so different JS bundles (vanilla/lit/etc.)
+ *   can swap implementations without changing HTML.
+ */
+
+import {ListEntriesElement} from '@src/Presentation/entries/vanilla/ListEntriesElement';
+
+/**
+ * Stable custom element tag name for UC-2 ListEntries.
+ */
+const tagName = 'dl-list-entries';
+
+/**
+ * Register ListEntriesElement under the stable tag name if not
+ * registered yet. This makes the entry file idempotent and safe
+ * to import from multiple places.
+ *
+ * @returns {void}
+ */
+function registerListEntriesElement(): void {
+    const existing = customElements.get(tagName);
+
+    if (!existing) {
+        const ctor = ListEntriesElement;
+
+        customElements.define(tagName, ctor);
+    }
+}
+
+registerListEntriesElement();

--- a/frontend/src/Presentation/runner/RunnerSuccess.ts
+++ b/frontend/src/Presentation/runner/RunnerSuccess.ts
@@ -1,4 +1,3 @@
-
 /**
  * Success envelope returned by UseCaseRunner.
  *

--- a/frontend/tests/Unit/Presentation/entries/vanilla/ListEntriesElement.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/ListEntriesElement.test.ts
@@ -106,9 +106,7 @@ function createErrorResponse(
  *
  * @returns {ListEntriesRunner} Runner whose run() method resolves with the response.
  */
-function createFakeRunner(
-    response: UseCaseResponse<ListEntriesPageInterface>
-): ListEntriesRunner {
+function createFakeRunner(response: UseCaseResponse<ListEntriesPageInterface>): ListEntriesRunner {
     const spy = vi.fn<[], Promise<UseCaseResponse<ListEntriesPageInterface>>>();
 
     spy.mockResolvedValue(response);

--- a/frontend/tests/Unit/Presentation/entries/vanilla/ListEntriesElement.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/ListEntriesElement.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @file ListEntriesElement.test.ts
+ *
+ * This test suite describes the behavior of the vanilla Web Component
+ * <dl-list-entries> for UC-2 (ListEntries).
+ *
+ * Scenarios:
+ * - shows loading state right after being connected to the DOM;
+ * - renders entries list when UC-2 returns a successful response;
+ * - renders error from the use-case response when success === false;
+ * - renders a generic error message when the runner throws.
+ */
+
+import {describe, it, expect, vi, beforeAll, beforeEach} from 'vitest';
+import {
+    ListEntriesElement,
+    type ListEntriesRunner
+} from '@src/Presentation/entries/vanilla/ListEntriesElement';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
+
+/**
+ * Ensures that ListEntriesElement constructor is registered
+ * in the CustomElementRegistry before we instantiate it directly.
+ *
+ * jsdom requires the constructor to be part of the registry;
+ * otherwise "Invalid constructor" is thrown.
+ *
+ * @returns {void}
+ */
+function ensureCustomElementRegistered(): void {
+    const tagName = 'dl-list-entries';
+    const existing = customElements.get(tagName);
+
+    if (!existing) {
+        const ctor = ListEntriesElement;
+        customElements.define(tagName, ctor);
+    }
+}
+
+/**
+ * Creates an empty ListEntriesPageInterface instance for baseline tests.
+ *
+ * @returns {ListEntriesPageInterface} Page object with zero items and default pagination.
+ */
+function createEmptyPage(): ListEntriesPageInterface {
+    const page: ListEntriesPageInterface = {
+        items: [],
+        page: 1,
+        perPage: 20,
+        total: 0,
+        pagesCount: 0
+    };
+
+    return page;
+}
+
+/**
+ * Wraps given page into a successful use-case response.
+ *
+ * @param {ListEntriesPageInterface} page Page data returned by UC-2.
+ *
+ * @returns {UseCaseResponse<ListEntriesPageInterface>} Successful response with provided data.
+ */
+function createSuccessResponse(
+    page: ListEntriesPageInterface
+): UseCaseResponse<ListEntriesPageInterface> {
+    const response: UseCaseResponse<ListEntriesPageInterface> = {
+        success: true,
+        code: null,
+        status: 200,
+        data: page,
+        errors: null
+    };
+
+    return response;
+}
+
+/**
+ * Wraps error information into a failed use-case response.
+ *
+ * @param {string} code Machine-readable error code.
+ * @param {string[]} errors Human-readable error messages.
+ *
+ * @returns {UseCaseResponse<ListEntriesPageInterface>} Failed response without data.
+ */
+function createErrorResponse(
+    code: string,
+    errors: string[]
+): UseCaseResponse<ListEntriesPageInterface> {
+    const response: UseCaseResponse<ListEntriesPageInterface> = {
+        success: false,
+        code,
+        status: 500,
+        data: null,
+        errors
+    };
+
+    return response;
+}
+
+/**
+ * Creates a fake runner that always resolves with the provided response.
+ *
+ * @param {UseCaseResponse<ListEntriesPageInterface>} response Predefined response.
+ *
+ * @returns {ListEntriesRunner} Runner whose run() method resolves with the response.
+ */
+function createFakeRunner(
+    response: UseCaseResponse<ListEntriesPageInterface>
+): ListEntriesRunner {
+    const spy = vi.fn<[], Promise<UseCaseResponse<ListEntriesPageInterface>>>();
+
+    spy.mockResolvedValue(response);
+
+    const runner: ListEntriesRunner = {
+        run: spy
+    };
+
+    return runner;
+}
+
+describe('ListEntriesElement', () => {
+    beforeAll(() => {
+        ensureCustomElementRegistered();
+    });
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('shows loading state immediately after connection', () => {
+        const page = createEmptyPage();
+        const response = createSuccessResponse(page);
+        const runner = createFakeRunner(response);
+
+        const element = new ListEntriesElement(runner);
+
+        document.body.appendChild(element);
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const loading = shadow.querySelector('[data-testid="loading"]');
+
+        expect(loading).not.toBeNull();
+        expect(loading?.textContent).toContain('Loading entries');
+    });
+
+    it('renders entries list when UC-2 returns items successfully', async () => {
+        const firstEntry = {
+            id: '11111111-1111-1111-1111-111111111111',
+            title: 'First entry title',
+            body: 'First entry body',
+            date: '2025-12-01',
+            createdAt: '2025-12-01T10:00:00Z',
+            updatedAt: '2025-12-01T10:00:00Z'
+        };
+
+        const secondEntry = {
+            id: '22222222-2222-2222-2222-222222222222',
+            title: 'Second entry title',
+            body: 'Second entry body',
+            date: '2025-12-02',
+            createdAt: '2025-12-02T10:00:00Z',
+            updatedAt: '2025-12-02T10:30:00Z'
+        };
+
+        const page: ListEntriesPageInterface = {
+            items: [firstEntry, secondEntry],
+            page: 1,
+            perPage: 20,
+            total: 2,
+            pagesCount: 1
+        };
+
+        const response = createSuccessResponse(page);
+        const runner = createFakeRunner(response);
+
+        const element = new ListEntriesElement(runner);
+
+        document.body.appendChild(element);
+
+        // allow pending microtasks (Promise chains) to resolve
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const loading = shadow.querySelector('[data-testid="loading"]');
+        const error = shadow.querySelector('[data-testid="error"]');
+        const items = shadow.querySelectorAll('[data-testid="entry-item"]');
+
+        expect(loading).toBeNull();
+        expect(error).toBeNull();
+        expect(items).toHaveLength(2);
+        expect(items[0].textContent).toContain('First entry title');
+        expect(items[1].textContent).toContain('Second entry title');
+    });
+
+    it('renders error state when UC-2 returns a failed response', async () => {
+        const errors = ['Unexpected error while listing entries'];
+        const response = createErrorResponse('LIST_ENTRIES_FAILED', errors);
+        const runner = createFakeRunner(response);
+
+        const element = new ListEntriesElement(runner);
+
+        document.body.appendChild(element);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const loading = shadow.querySelector('[data-testid="loading"]');
+        const error = shadow.querySelector('[data-testid="error"]');
+
+        expect(loading).toBeNull();
+        expect(error).not.toBeNull();
+        expect(error?.textContent).toContain('Unexpected error while listing entries');
+    });
+
+    it('renders generic error message when UC-2 runner throws', async () => {
+        const failingRunner: ListEntriesRunner = {
+            run: vi.fn().mockRejectedValue(new Error('Network broken'))
+        };
+
+        const element = new ListEntriesElement(failingRunner);
+
+        document.body.appendChild(element);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const loading = shadow.querySelector('[data-testid="loading"]');
+        const error = shadow.querySelector('[data-testid="error"]');
+
+        expect(loading).toBeNull();
+        expect(error).not.toBeNull();
+        expect(error?.textContent).toContain('Failed to load entries');
+    });
+});

--- a/frontend/tests/Unit/Presentation/entries/vanilla/list.vanilla.entry.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/list.vanilla.entry.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @file list.vanilla.entry.test.ts
+ *
+ * This test verifies that the vanilla entry file for UC-2 (ListEntries)
+ * registers the <dl-list-entries> custom element in the CustomElementRegistry.
+ *
+ * It guarantees:
+ * - the HTML tag remains a stable contract;
+ * - the registered constructor is ListEntriesElement;
+ * - switching bundles later (vanilla/lit/etc.) only changes the implementation
+ *   behind the same tag name.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {ListEntriesElement} from '@src/Presentation/entries/vanilla/ListEntriesElement';
+
+describe('list.vanilla.entry', () => {
+    it('registers <dl-list-entries> with ListEntriesElement constructor', async () => {
+        const tagName = 'dl-list-entries';
+
+        // Import entry file that performs registration as a side effect.
+        await import('@src/Presentation/entries/vanilla/list.vanilla.entry');
+
+        const registeredConstructor = customElements.get(tagName);
+
+        expect(registeredConstructor).toBe(ListEntriesElement);
+    });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,7 @@
         "useDefineForClassFields": true,
         "module": "ESNext",
         "lib": ["ES2022", "DOM", "DOM.Iterable"],
-        "types": ["vite/client"],
+        "types": ["vite/client", "node"],
         "skipLibCheck": true,
 
         /* Bundler mode */

--- a/frontend/ui/scss/dl-list-entries.scss
+++ b/frontend/ui/scss/dl-list-entries.scss
@@ -1,0 +1,77 @@
+// =======================================
+// Variables
+// =======================================
+$color-text: #000;
+$color-text-muted: #555;
+$color-border: #ddd;
+$color-error: #b00020;
+$color-button-bg: #f5f5f5;
+$color-button-border: #e0e0e0;
+
+// =======================================
+// Component styles
+// =======================================
+:host {
+    display: block;
+    font-family:
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
+    color: $color-text;
+
+    .dl-list-entries__loading {
+        padding: 0.5rem 0;
+        font-size: 0.9rem;
+        opacity: 0.75;
+    }
+
+    .dl-list-entries__error {
+        padding: 0.5rem 0;
+        font-size: 0.9rem;
+        color: $color-error;
+    }
+
+    .dl-list-entries__items {
+        list-style: none;
+        padding: 0;
+        margin: 0.5rem 0 0;
+    }
+
+    .dl-list-entries__item {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid $color-border;
+
+        &-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.5rem;
+        }
+
+        &-number {
+            font-weight: 600;
+        }
+
+        &-title {
+            margin: 0 0 0.25rem;
+            font-weight: 500;
+        }
+
+        &-body {
+            margin: 0;
+            font-size: 0.9rem;
+            color: $color-text-muted;
+        }
+    }
+
+    .dl-list-entries__view-button {
+        font-size: 0.85rem;
+        padding: 0.25rem 0.75rem;
+        border-radius: 4px;
+        border: 1px solid $color-button-border;
+        background: $color-button-bg;
+        cursor: pointer;
+    }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,26 @@
 import {defineConfig} from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import path from 'path';
 
 export default defineConfig({
-    plugins: [tsconfigPaths()]
+    plugins: [tsconfigPaths()],
+
+    build: {
+        outDir: path.resolve(__dirname, '../public/assets'),
+        emptyOutDir: true,
+
+        rollupOptions: {
+            input: {
+                'entries-list-vanilla': path.resolve(
+                    __dirname,
+                    'src/Presentation/entries/vanilla/list.vanilla.entry.ts'
+                )
+            },
+            output: {
+                entryFileNames: 'js/[name].js',
+                chunkFileNames: 'js/[name].js',
+                assetFileNames: 'assets/[name][extname]'
+            }
+        }
+    }
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,25 +1,36 @@
 import {defineConfig} from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import path from 'path';
+
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {dirname} from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig({
+    root: path.resolve(__dirname),
     plugins: [tsconfigPaths()],
-
     build: {
         outDir: path.resolve(__dirname, '../public/assets'),
-        emptyOutDir: true,
-
+        emptyOutDir: false,
         rollupOptions: {
             input: {
                 'entries-list-vanilla': path.resolve(
                     __dirname,
                     'src/Presentation/entries/vanilla/list.vanilla.entry.ts'
-                )
+                ),
+
+                'dl-list-entries': path.resolve(__dirname, 'ui/scss/dl-list-entries.scss')
             },
             output: {
-                entryFileNames: 'js/[name].js',
-                chunkFileNames: 'js/[name].js',
-                assetFileNames: 'assets/[name][extname]'
+                assetFileNames: (asset) => {
+                    if (asset.name?.endsWith('.css')) {
+                        return 'css/[name][extname]';
+                    }
+                    return 'js/[name][extname]';
+                },
+                entryFileNames: 'js/[name].js'
             }
         }
     }


### PR DESCRIPTION
Implements the vanilla Web Component for UC-2 (ListEntries) and a stable entry file that registers <dl-list-entries>, enabling loading/error/data states via shadow DOM and keeping the HTML tag fixed for future UI implementation swaps.

Resolve #57