### PR TITLE
feat: implement view page and vanilla wc for GetEntry useCase

### DIFF
--- a/backend/config/routes.ini
+++ b/backend/config/routes.ini
@@ -3,6 +3,7 @@
 ; UI routes (Presentation layer)
 GET    /                    = Daylog\Presentation\Controllers\Index\Page\IndexPageController->show
 GET    /entries             = Daylog\Presentation\Controllers\Entries\Page\EntriesListPageController->show
+GET    /entries/@id         = Daylog\Presentation\Controllers\Entries\Page\EntryViewPageController->show
 GET    /entries/create      = Daylog\Presentation\Controllers\Entries\Page\EntryCreatePageController->show
 GET    /entries/@id/edit    = Daylog\Presentation\Controllers\Entries\Page\EntryEditPageController->show
 

--- a/backend/src/Presentation/Controllers/Entries/Page/EntryViewPageController.php
+++ b/backend/src/Presentation/Controllers/Entries/Page/EntryViewPageController.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Daylog\Presentation\Controllers\Entries\Page;
+use Daylog\Presentation\Controllers\BaseController;
+use Daylog\Presentation\Views\ResponsePayload;
+use Daylog\Presentation\Http\HttpRequest;
+
+/**
+ * Controller for displaying the entry editing form (HTML).
+ *
+ * Purpose:
+ * - Provide template and script information for the edit entry page.
+ * - Wrap page data into ResponsePayload for consistent rendering.
+ */
+final class EntryViewPageController extends BaseController
+{
+    /**
+     * Show the entry edit page.
+     *
+     * @return void
+     */
+    public function show(): void
+    {
+        $params = HttpRequest::params();
+
+        $data = [
+            'template' => 'entry-view.html',
+            'script'   => 'entry-view-vanilla.js',
+            'entryId'  => $params['id']
+        ];
+
+        $payload = ResponsePayload::success()
+            ->withStatus(200)
+            ->withData($data);
+
+        $this->response->setHtml($payload);
+    }
+}
+
+

--- a/backend/src/Presentation/Templates/pages/entry-view.html
+++ b/backend/src/Presentation/Templates/pages/entry-view.html
@@ -1,0 +1,5 @@
+<h1>Daylog &ndash; UC-3: Get Entry</h1>
+
+<dl-entry
+    entry-id="{{ @entryId }}">
+</dl-entry>

--- a/backend/src/Presentation/Views/Renderers/HtmlView.php
+++ b/backend/src/Presentation/Views/Renderers/HtmlView.php
@@ -68,22 +68,28 @@ final class HtmlView extends BaseView
         }
 
         $template = sprintf('pages/%s', $data['template']);
+        unset($data['template']);
 
         $pageTitle = 'Daylog';
         if (array_key_exists('pageTitle', $data) && is_string($data['pageTitle'])) {
             $pageTitle = $data['pageTitle'];
+
+            unset($data['pageTitle']);
         }
 
         $pageScripts = '';
         if (array_key_exists('script', $data) && is_string($data['script'])) {
             $scriptSrc   = $data['script'];
             $pageScripts = sprintf('<script type="module" src="/assets/js/%s"></script>', $scriptSrc);
+
+            unset($data['script']);
         }
 
         $f3 = Base::instance();
         $f3->set('pageTitle', $pageTitle);
         $f3->set('contentTemplate', $template);
         $f3->set('pageScripts', $pageScripts);
+        $f3->mset($data);
 
         $layoutPath     = 'layouts/base.html';
         $templateEngine = Template::instance();

--- a/frontend/src/Presentation/entries/vanilla/list/ListEntriesElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/list/ListEntriesElement.ts
@@ -17,7 +17,7 @@
  */
 
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
-import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
+import type {ListEntriesData} from '@src/Application/DTO/Entries/ListEntries/ListEntriesResponse';
 import type {ListEntriesRunner} from './ListEntriesRunner';
 import {createListEntriesRunner} from './ListEntriesRunner';
 
@@ -93,7 +93,7 @@ export class ListEntriesElement extends HTMLElement {
         return message;
     }
 
-    private pickErrorMessage(response: UseCaseResponse<ListEntriesPageInterface>): string {
+    private pickErrorMessage(response: UseCaseResponse<ListEntriesData>): string {
         const errors = response.errors;
 
         if (errors && errors.length) {
@@ -131,7 +131,7 @@ export class ListEntriesElement extends HTMLElement {
         this.root.innerHTML = html;
     }
 
-    private renderData(page: ListEntriesPageInterface): void {
+    private renderData(page: ListEntriesData): void {
         if (!page.items.length) {
             const html = `
                 <div class="dl-list-entries container" data-testid="empty">
@@ -154,14 +154,21 @@ export class ListEntriesElement extends HTMLElement {
                 const numberText = `№ ${number}. ${entry.date}`;
                 const titleText = entry.title;
                 const bodyText = entry.body;
+                const entryId = entry.id;
+
+                const entryUrl = `/entries/${entryId}`;
 
                 const itemHtml = `
                     <div class="box" data-testid="entry-item">
                         <div class="is-flex is-justify-content-space-between is-align-items-center">
                             <span class="has-text-grey">${numberText}</span>
-                            <button class="button is-link is-small" type="button">
-                                Просмотреть
-                            </button>
+                            <a
+                                href="${entryUrl}"
+                                class="button is-link is-small"
+                                data-testid="entry-view-link"
+                            >
+                                View
+                            </a>
                         </div>
 
                         <p class="title is-6 mt-3">${titleText}</p>

--- a/frontend/src/Presentation/entries/vanilla/list/ListEntriesRunner.ts
+++ b/frontend/src/Presentation/entries/vanilla/list/ListEntriesRunner.ts
@@ -1,21 +1,21 @@
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
-import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
+import type {ListEntriesData} from '@src/Application/DTO/Entries/ListEntries/ListEntriesResponse';
 import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
 import {makeListEntriesUseCase} from '@src/Configuration/Providers/Entries/ListEntriesProvider';
 
 export interface ListEntriesRunner {
-    run: () => Promise<UseCaseResponse<ListEntriesPageInterface>>;
+    run: () => Promise<UseCaseResponse<ListEntriesData>>;
 }
 
 export function createListEntriesRunner(): ListEntriesRunner {
     const useCase = makeListEntriesUseCase();
 
     const listEntriesRunner: ListEntriesRunner = {
-        run: async (): Promise<UseCaseResponse<ListEntriesPageInterface>> => {
+        run: async (): Promise<UseCaseResponse<ListEntriesData>> => {
             const params = {};
 
             const runnerResult = await UseCaseRunner.run(useCase, params);
-            const response = runnerResult as UseCaseResponse<ListEntriesPageInterface>;
+            const response = runnerResult as UseCaseResponse<ListEntriesData>;
 
             return response;
         }

--- a/frontend/src/Presentation/entries/vanilla/list/list.vanilla.entry.ts
+++ b/frontend/src/Presentation/entries/vanilla/list/list.vanilla.entry.ts
@@ -7,7 +7,7 @@
  *   can swap implementations without changing HTML.
  */
 
-import {ListEntriesElement} from '@src/Presentation/entries/vanilla/ListEntriesElement';
+import {ListEntriesElement} from '@src/Presentation/entries/vanilla/list/ListEntriesElement';
 
 /**
  * Stable custom element tag name for UC-2 ListEntries.

--- a/frontend/src/Presentation/entries/vanilla/view/EntryElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/view/EntryElement.ts
@@ -1,0 +1,233 @@
+/**
+ * Vanilla Web Component for UC-3 (GetEntry).
+ *
+ * Purpose:
+ * - Execute UC-3 via UseCaseRunner + GetEntry provider.
+ * - Render three UI states inside shadow DOM: loading, error, data.
+ *
+ * Mechanics:
+ * - A shared stylesheet <link> (/assets/css/dl-components.css) is appended once
+ *   and kept in shadow root.
+ * - All render methods update only a dedicated root container, so the stylesheet
+ *   is never removed during re-rendering.
+ * - Entry id is read from the `entry-id` attribute. On changes, the component
+ *   re-runs the use case and re-renders.
+ *
+ * Notes:
+ * - The component depends on runner/provider wiring only.
+ * - It does not access HTTP or repositories directly.
+ */
+
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {GetEntryResponse} from '@src/Application/DTO/Entries/GetEntry/GetEntryResponse';
+import type {EntryRunner} from './EntryRunner';
+import {createEntryRunner} from './EntryRunner';
+
+export class EntryElement extends HTMLElement {
+    private static readonly entryIdAttribute = 'entry-id';
+
+    private readonly runner: EntryRunner;
+    private readonly root: HTMLDivElement;
+
+    public constructor(runner?: EntryRunner) {
+        super();
+
+        const shadow = this.attachShadow({mode: 'open'});
+
+        this.runner = runner ?? createEntryRunner();
+
+        this.loadStyles(shadow);
+
+        this.root = document.createElement('div');
+        shadow.appendChild(this.root);
+    }
+
+    public static get observedAttributes(): string[] {
+        const attribute = EntryElement.entryIdAttribute;
+
+        const attributes = [attribute];
+
+        return attributes;
+    }
+
+    public connectedCallback(): void {
+        this.renderLoading();
+
+        this.run();
+    }
+
+    public attributeChangedCallback(
+        name: string,
+        oldValue: string | null,
+        newValue: string | null
+    ): void {
+        const watched = EntryElement.entryIdAttribute;
+
+        if (name !== watched) {
+            return;
+        }
+
+        if (oldValue === newValue) {
+            return;
+        }
+
+        if (!this.isConnected) {
+            return;
+        }
+
+        this.renderLoading();
+
+        this.run();
+    }
+
+    private async run(): Promise<void> {
+        try {
+            const entryId = this.getEntryId();
+
+            if (!entryId) {
+                const message = 'Entry id is missing.';
+                this.renderError(message);
+
+                return;
+            }
+
+            const response = await this.runner.run(entryId);
+
+            if (response.success) {
+                const data = response.data;
+
+                if (!data) {
+                    const message = 'Failed to load entry. Please try again.';
+                    this.renderError(message);
+
+                    return;
+                }
+
+                this.renderData(data);
+
+                return;
+            }
+
+            const message = this.pickErrorMessage(response);
+
+            this.renderError(message);
+        } catch (error) {
+            const message = this.normalizeError(error);
+
+            this.renderError(message);
+        }
+    }
+
+    private getEntryId(): string {
+        const attribute = EntryElement.entryIdAttribute;
+
+        const raw = this.getAttribute(attribute);
+
+        if (!raw) {
+            const empty = '';
+            return empty;
+        }
+
+        const trimmed = raw.trim();
+
+        return trimmed;
+    }
+
+    private loadStyles(shadow: ShadowRoot): void {
+        const href = '/assets/css/dl-components.css';
+
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+
+        shadow.appendChild(link);
+    }
+
+    private normalizeError(error: unknown): string {
+        if (error instanceof Error) {
+            const message = error.message;
+            return message;
+        }
+
+        const message = 'Failed to load entry. Please try again.';
+        return message;
+    }
+
+    private pickErrorMessage(response: UseCaseResponse<GetEntryResponse>): string {
+        const errors = response.errors;
+
+        if (errors && errors.length) {
+            const message = errors.join(', ');
+            return message;
+        }
+
+        const fallback = 'Failed to load entry. Please try again.';
+
+        return fallback;
+    }
+
+    private renderLoading(): void {
+        const html = `
+            <div class="dl-entry container" data-testid="loading">
+                <div class="box">
+                    <progress class="progress is-small is-primary" max="100">Loading</progress>
+                    <p class="has-text-grey">Loading entry&hellip;</p>
+                </div>
+            </div>
+        `;
+
+        this.root.innerHTML = html;
+    }
+
+    private renderError(message: string): void {
+        const html = `
+            <div class="dl-entry container" data-testid="error">
+                <article class="message is-danger is-light">
+                    <div class="message-body">
+                        ${message}
+                    </div>
+                </article>
+            </div>
+        `;
+
+        this.root.innerHTML = html;
+    }
+
+    private renderData(entry: GetEntryResponse): void {
+        const titleText = entry.title;
+        const dateText = entry.date;
+        const bodyText = entry.body;
+
+        const html = `
+            <div class="dl-entry container" data-testid="data">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">
+                            ${titleText}
+                        </p>
+                    </header>
+
+                    <div class="card-content">
+                        <div class="content">
+                            <p class="has-text-grey">
+                                ${dateText}
+                            </p>
+
+                            <hr />
+
+                            <p>
+                                ${bodyText}
+                            </p>
+                        </div>
+                    </div>
+
+                    <footer class="card-footer">
+                        <a class="card-footer-item" href="/entries">Back to list</a>
+                    </footer>
+                </div>
+            </div>
+        `;
+
+        this.root.innerHTML = html;
+    }
+}

--- a/frontend/src/Presentation/entries/vanilla/view/EntryRunner.ts
+++ b/frontend/src/Presentation/entries/vanilla/view/EntryRunner.ts
@@ -1,0 +1,28 @@
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {GetEntryResponse} from '@src/Application/DTO/Entries/GetEntry/GetEntryResponse';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+import {makeGetEntryUseCase} from '@src/Configuration/Providers/Entries/GetEntryProvider';
+
+export interface EntryRunner {
+    // eslint-disable-next-line no-unused-vars
+    run: (entryId: string) => Promise<UseCaseResponse<GetEntryResponse>>;
+}
+
+export function createEntryRunner(): EntryRunner {
+    const useCase = makeGetEntryUseCase();
+
+    const entryRunner: EntryRunner = {
+        run: async (entryId: string): Promise<UseCaseResponse<GetEntryResponse>> => {
+            const params = {
+                id: entryId
+            };
+
+            const runnerResult = await UseCaseRunner.run(useCase, params);
+            const response = runnerResult as UseCaseResponse<GetEntryResponse>;
+
+            return response;
+        }
+    };
+
+    return entryRunner;
+}

--- a/frontend/src/Presentation/entries/vanilla/view/view.vanilla.entry.ts
+++ b/frontend/src/Presentation/entries/vanilla/view/view.vanilla.entry.ts
@@ -1,0 +1,34 @@
+/**
+ * Entry file for vanilla implementation of UC-3 (GetEntry).
+ *
+ * Purpose:
+ * - Register <dl-entry> custom element in the global registry.
+ * - Keep tag name stable so different JS bundles (vanilla/lit/etc.)
+ *   can swap implementations without changing HTML.
+ */
+
+import {EntryElement} from '@src/Presentation/entries/vanilla/view/EntryElement';
+
+/**
+ * Stable custom element tag name for UC-3 GetEntry.
+ */
+const tagName = 'dl-entry';
+
+/**
+ * Register EntryElement under the stable tag name if not
+ * registered yet. This makes the entry file idempotent and safe
+ * to import from multiple places.
+ *
+ * @returns {void}
+ */
+function registerEntryElement(): void {
+    const existing = customElements.get(tagName);
+
+    if (!existing) {
+        const ctor = EntryElement;
+
+        customElements.define(tagName, ctor);
+    }
+}
+
+registerEntryElement();

--- a/frontend/tests/Unit/Presentation/entries/vanilla/ListEntriesElement.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/ListEntriesElement.test.ts
@@ -15,7 +15,7 @@ import {describe, it, expect, vi, beforeAll, beforeEach} from 'vitest';
 import {
     ListEntriesElement,
     type ListEntriesRunner
-} from '@src/Presentation/entries/vanilla/ListEntriesElement';
+} from '@src/Presentation/entries/vanilla/list/ListEntriesElement';
 import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
 import type {ListEntriesPageInterface} from '@src/Domain/Interfaces/Entries/ListEntriesPageInterface';
 

--- a/frontend/tests/Unit/Presentation/entries/vanilla/list.vanilla.entry.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/list.vanilla.entry.test.ts
@@ -12,14 +12,14 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {ListEntriesElement} from '@src/Presentation/entries/vanilla/ListEntriesElement';
+import {ListEntriesElement} from '@src/Presentation/entries/vanilla/list/ListEntriesElement';
 
 describe('list.vanilla.entry', () => {
     it('registers <dl-list-entries> with ListEntriesElement constructor', async () => {
         const tagName = 'dl-list-entries';
 
         // Import entry file that performs registration as a side effect.
-        await import('@src/Presentation/entries/vanilla/list.vanilla.entry');
+        await import('@src/Presentation/entries/vanilla/list/list.vanilla.entry');
 
         const registeredConstructor = customElements.get(tagName);
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,22 @@ import {dirname} from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+/**
+ * Resolve project-relative paths for Rollup/Vite inputs.
+ *
+ * Purpose:
+ * Provide a short, explicit helper to keep rollup input configuration readable
+ * while preserving a single source of truth for __dirname-based resolution.
+ *
+ * @param relativePath string Project-relative path from repository root.
+ * @return string Absolute filesystem path.
+ */
+function r(relativePath: string): string {
+    const resolvedPath = path.resolve(__dirname, relativePath);
+
+    return resolvedPath;
+}
+
 export default defineConfig({
     root: path.resolve(__dirname),
     base: '/assets/',
@@ -18,12 +34,15 @@ export default defineConfig({
         emptyOutDir: false,
         rollupOptions: {
             input: {
-                'entries-list-vanilla': path.resolve(
-                    __dirname,
-                    'src/Presentation/entries/vanilla/list.vanilla.entry.ts'
+                'entries-list-vanilla': r(
+                    'src/Presentation/entries/vanilla/list/list.vanilla.entry.ts'
                 ),
 
-                'dl-components': path.resolve(__dirname, 'ui/scss/dl-components.scss')
+                'entry-view-vanilla': r(
+                    'src/Presentation/entries/vanilla/view/view.vanilla.entry.ts'
+                ),
+
+                'dl-components': r('ui/scss/dl-components.scss')
             },
             output: {
                 assetFileNames: (asset) => {


### PR DESCRIPTION
Add entry details page using a vanilla Web Component.
Introduce view wiring, runner, and bundle entry while keeping stable HTML contract and clean layer boundaries.

Resolve #62