### PR TITLE
feat(entry): add edit entry page with vanilla Web Component (UC-5)

### DIFF
--- a/backend/src/Presentation/Controllers/Entries/Page/EntryEditPageController.php
+++ b/backend/src/Presentation/Controllers/Entries/Page/EntryEditPageController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Daylog\Presentation\Controllers\Entries\Page;
 use Daylog\Presentation\Controllers\BaseController;
 use Daylog\Presentation\Views\ResponsePayload;
+use Daylog\Presentation\Http\HttpRequest;
 
 /**
  * Controller for displaying the entry editing form (HTML).
@@ -21,9 +22,13 @@ final class EntryEditPageController extends BaseController
      */
     public function show(): void
     {
+        $params = HttpRequest::params();
+        $entryId = $params['id'];
+
         $data = [
-            'template' => 'edit.html',
-            'script'   => 'edit.js',
+            'entryId'  => $entryId,
+            'template' => 'entry-edit.html',
+            'script'   => 'entry-edit-vanilla.js',
         ];
 
         $payload = ResponsePayload::success()

--- a/backend/src/Presentation/Templates/pages/entry-edit.html
+++ b/backend/src/Presentation/Templates/pages/entry-edit.html
@@ -1,0 +1,3 @@
+<h1>Daylog &ndash; UC-5: Edit Entry</h1>
+
+<dl-entry-edit entry-id="{{ @entryId }}"></dl-entry-edit>

--- a/frontend/src/Presentation/entries/vanilla/add/AddEntryElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/add/AddEntryElement.ts
@@ -11,7 +11,7 @@
  * - All render methods update only a dedicated root container, so the stylesheet
  *   is never removed during re-rendering.
  * - On successful creation, the component dispatches a `dl-entry-created` event
- *   with `{ id }` and optionally redirects using `redirect-to="/entries/{id}"`.
+ *   with `{ id }`.
  *
  * Notes:
  * - The component depends on runner/provider wiring only.
@@ -22,10 +22,12 @@ import type {Entry} from '@src/Domain/Models/Entries/Entry';
 import type {AddEntryResponse} from '@src/Application/DTO/Entries/AddEntry/AddEntryResponse';
 import type {AddEntryRunner} from './AddEntryRunner';
 import {createAddEntryRunner} from './AddEntryRunner';
+import {EntryFormView, type EntryFormParams} from '@src/Presentation/entries/vanilla/form/EntryFormView';
 
 export class AddEntryElement extends HTMLElement {
     private readonly runner: AddEntryRunner;
     private readonly root: HTMLDivElement;
+    private readonly formView: EntryFormView;
 
     private isSubmitting = false;
 
@@ -40,6 +42,17 @@ export class AddEntryElement extends HTMLElement {
 
         this.root = document.createElement('div');
         shadow.appendChild(this.root);
+
+        this.formView = new EntryFormView({
+            containerClass: 'dl-entry-add',
+            labels: {
+                heading: 'New entry',
+                submit: 'Save',
+                cancel: 'Cancel',
+                dateHelp: 'Logical entry date, not timestamps.',
+                submittingText: 'Saving entry…'
+            }
+        });
     }
 
     public connectedCallback(): void {
@@ -58,35 +71,22 @@ export class AddEntryElement extends HTMLElement {
     }
 
     private bindEvents(): void {
-        const form = this.root.querySelector('form[data-testid="form"]');
+        this.formView.bind(this.root, {
+            onSubmit: (params: EntryFormParams) => {
+                if (this.isSubmitting) {
+                    return;
+                }
 
-        if (!form) {
-            return;
-        }
-
-        form.addEventListener('submit', (event: Event) => {
-            event.preventDefault();
-
-            if (this.isSubmitting) {
-                return;
-            }
-
-            this.submit();
-        });
-
-        const cancel = this.root.querySelector('button[data-testid="cancel"]');
-
-        if (cancel) {
-            cancel.addEventListener('click', () => {
+                this.submit(params);
+            },
+            onCancel: () => {
                 this.onCancel();
-            });
-        }
+            }
+        });
     }
 
-    private async submit(): Promise<void> {
+    private async submit(params: EntryFormParams): Promise<void> {
         this.isSubmitting = true;
-
-        const params = this.readFormParams();
 
         this.renderSubmitting(params);
         this.bindEvents();
@@ -131,39 +131,6 @@ export class AddEntryElement extends HTMLElement {
         }
     }
 
-    private readFormParams(): {title: string; body: string; date: string} {
-        const title = this.readInputValue('title');
-        const body = this.readInputValue('body');
-        const date = this.readInputValue('date');
-
-        const params = {title, body, date};
-
-        return params;
-    }
-
-    private readInputValue(name: 'title' | 'body' | 'date'): string {
-        const selector = `[name="${name}"]`;
-        const node = this.root.querySelector(selector);
-
-        if (!node) {
-            const empty = '';
-            return empty;
-        }
-
-        if (node instanceof HTMLInputElement) {
-            const value = node.value.trim();
-            return value;
-        }
-
-        if (node instanceof HTMLTextAreaElement) {
-            const value = node.value.trim();
-            return value;
-        }
-
-        const empty = '';
-        return empty;
-    }
-
     private pickErrorMessage(response: AddEntryResponse): string {
         const errors = response.errors;
 
@@ -176,194 +143,16 @@ export class AddEntryElement extends HTMLElement {
         return fallback;
     }
 
-    private renderForm(params?: {title: string; body: string; date: string}): void {
-        const titleValue = params?.title ?? '';
-        const bodyValue = params?.body ?? '';
-        const dateValue = params?.date ?? '';
-
-        const html = `
-            <div class="dl-entry-add container" data-testid="idle">
-                <div class="card">
-                    <header class="card-header">
-                        <p class="card-header-title">
-                            New entry
-                        </p>
-                    </header>
-
-                    <div class="card-content">
-                        <div class="content">
-                            <form data-testid="form">
-                                <div class="field">
-                                    <label class="label">Title</label>
-                                    <div class="control">
-                                        <input
-                                            class="input"
-                                            type="text"
-                                            name="title"
-                                            value="${this.escapeAttr(titleValue)}"
-                                            autocomplete="off"
-                                            required
-                                        />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <label class="label">Date</label>
-                                    <div class="control">
-                                        <input
-                                            class="input"
-                                            type="date"
-                                            name="date"
-                                            value="${this.escapeAttr(dateValue)}"
-                                            placeholder="YYYY-MM-DD"
-                                            autocomplete="off"
-                                            required
-                                        />
-                                    </div>
-                                    <p class="help">Logical entry date, not timestamps.</p>
-                                </div>
-
-                                <div class="field">
-                                    <label class="label">Body</label>
-                                    <div class="control">
-                                        <textarea
-                                            class="textarea"
-                                            name="body"
-                                            rows="8"
-                                            required
-                                        >${this.escapeHtml(bodyValue)}</textarea>
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="control">
-                                        <div class="buttons">
-                                            <button class="button is-primary" type="submit">
-                                                Save
-                                            </button>
-
-                                            <button
-                                                class="button"
-                                                type="button"
-                                                data-testid="cancel"
-                                            >
-                                                Cancel
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        `;
-
-        this.root.innerHTML = html;
+    private renderForm(params?: EntryFormParams): void {
+        this.formView.renderIdle(this.root, params);
     }
 
-    private renderSubmitting(params: {title: string; body: string; date: string}): void {
-        const titleValue = params.title;
-        const bodyValue = params.body;
-        const dateValue = params.date;
-
-        const html = `
-            <div class="dl-entry-add container" data-testid="submitting">
-                <div class="card">
-                    <header class="card-header">
-                        <p class="card-header-title">
-                            New entry
-                        </p>
-                    </header>
-
-                    <div class="card-content">
-                        <div class="content">
-                            <progress class="progress is-small is-primary" max="100">Loading</progress>
-                            <p class="has-text-grey">Saving entry&hellip;</p>
-
-                            <hr />
-
-                            <form data-testid="form">
-                                <div class="field">
-                                    <label class="label">Title</label>
-                                    <div class="control">
-                                        <input
-                                            class="input"
-                                            type="text"
-                                            name="title"
-                                            value="${this.escapeAttr(titleValue)}"
-                                            disabled
-                                        />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <label class="label">Date</label>
-                                    <div class="control">
-                                        <input
-                                            class="input"
-                                            type="text"
-                                            name="date"
-                                            value="${this.escapeAttr(dateValue)}"
-                                            disabled
-                                        />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <label class="label">Body</label>
-                                    <div class="control">
-                                        <textarea
-                                            class="textarea"
-                                            name="body"
-                                            rows="8"
-                                            disabled
-                                        >${this.escapeHtml(bodyValue)}</textarea>
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="control">
-                                        <div class="buttons">
-                                            <button class="button is-primary" type="button" disabled>
-                                                Save
-                                            </button>
-
-                                            <button class="button" type="button" data-testid="cancel" disabled>
-                                                Cancel
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        `;
-
-        this.root.innerHTML = html;
+    private renderSubmitting(params: EntryFormParams): void {
+        this.formView.renderSubmitting(this.root, params);
     }
 
-    private renderError(
-        message: string,
-        params: {title: string; body: string; date: string}
-    ): void {
-        const html = `
-            <div class="dl-entry-add container" data-testid="error">
-                <article class="message is-danger is-light">
-                    <div class="message-body">
-                        ${this.escapeHtml(message)}
-                    </div>
-                </article>
-
-                <div class="mt-4">
-                    ${this.renderFormHtml(params)}
-                </div>
-            </div>
-        `;
-
-        this.root.innerHTML = html;
+    private renderError(message: string, params: EntryFormParams): void {
+        this.formView.renderError(this.root, message, params);
     }
 
     private renderSuccess(entry: Entry): void {
@@ -413,86 +202,6 @@ export class AddEntryElement extends HTMLElement {
         this.root.innerHTML = html;
     }
 
-    private renderFormHtml(params: {title: string; body: string; date: string}): string {
-        const titleValue = params.title;
-        const bodyValue = params.body;
-        const dateValue = params.date;
-
-        const html = `
-            <div class="card">
-                <header class="card-header">
-                    <p class="card-header-title">
-                        New entry
-                    </p>
-                </header>
-
-                <div class="card-content">
-                    <div class="content">
-                        <form data-testid="form">
-                            <div class="field">
-                                <label class="label">Title</label>
-                                <div class="control">
-                                    <input
-                                        class="input"
-                                        type="text"
-                                        name="title"
-                                        value="${this.escapeAttr(titleValue)}"
-                                        autocomplete="off"
-                                    />
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Date</label>
-                                <div class="control">
-                                    <input
-                                        class="input"
-                                        type="text"
-                                        name="date"
-                                        value="${this.escapeAttr(dateValue)}"
-                                        placeholder="YYYY-MM-DD"
-                                        autocomplete="off"
-                                    />
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Body</label>
-                                <div class="control">
-                                    <textarea
-                                        class="textarea"
-                                        name="body"
-                                        rows="8"
-                                    >${this.escapeHtml(bodyValue)}</textarea>
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <div class="control">
-                                    <div class="buttons">
-                                        <button class="button is-primary" type="submit">
-                                            Save
-                                        </button>
-
-                                        <button
-                                            class="button"
-                                            type="button"
-                                            data-testid="cancel"
-                                        >
-                                            Cancel
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        `;
-
-        return html;
-    }
-
     private afterSuccess(entry: Entry): void {
         const idText = (entry as unknown as {id?: string}).id ?? '';
 
@@ -519,11 +228,6 @@ export class AddEntryElement extends HTMLElement {
             .replaceAll('"', '&quot;')
             .replaceAll("'", '&#039;');
 
-        return escaped;
-    }
-
-    private escapeAttr(value: string): string {
-        const escaped = this.escapeHtml(value);
         return escaped;
     }
 }

--- a/frontend/src/Presentation/entries/vanilla/edit/EditEntryElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/edit/EditEntryElement.ts
@@ -1,0 +1,333 @@
+/**
+ * Vanilla Web Component for UC-5 (UpdateEntry), using UC-3 (GetEntry) for prefill.
+ *
+ * Purpose:
+ * - Load an entry by id (UC-3) and prefill the shared entry form UI.
+ * - Submit updated values (UC-5) via UseCaseRunner + UpdateEntry provider.
+ * - Render UI states inside shadow DOM: loading, idle, submitting, error, success.
+ *
+ * Mechanics:
+ * - A shared stylesheet <link> (/assets/css/dl-components.css) is appended once
+ *   and kept in shadow root.
+ * - The component keeps a dedicated root container and re-renders within it.
+ * - Entry id is read from the `entry-id` attribute. On changes, the component reloads data.
+ * - Form UI is delegated to EntryFormView to avoid duplication with AddEntry.
+ *
+ * Notes:
+ * - The component depends on runner/provider wiring only.
+ * - It does not access HTTP or repositories directly.
+ * - The component does not redirect or navigate on success; it emits an event.
+ */
+
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {GetEntryResponse} from '@src/Application/DTO/Entries/GetEntry/GetEntryResponse';
+import type {Entry} from '@src/Domain/Models/Entries/Entry';
+import {EntryFormView, type EntryFormParams} from '@src/Presentation/entries/vanilla/form/EntryFormView';
+import type {EntryRunner} from '@src/Presentation/entries/vanilla/view/EntryRunner';
+import {createEntryRunner} from '@src/Presentation/entries/vanilla/view/EntryRunner';
+import type {UpdateEntryRunner} from './UpdateEntryRunner';
+import {createUpdateEntryRunner} from './UpdateEntryRunner';
+
+type UpdateParams = {
+    id: string;
+    title: string;
+    body: string;
+    date: string;
+};
+
+export class EditEntryElement extends HTMLElement {
+    private static readonly entryIdAttribute = 'entry-id';
+
+    private readonly getRunner: EntryRunner;
+    private readonly updateRunner: UpdateEntryRunner;
+    private readonly root: HTMLDivElement;
+    private readonly formView: EntryFormView;
+
+    private isSubmitting = false;
+
+    public constructor(getRunner?: EntryRunner, updateRunner?: UpdateEntryRunner) {
+        super();
+
+        const shadow = this.attachShadow({mode: 'open'});
+
+        this.getRunner = getRunner ?? createEntryRunner();
+        this.updateRunner = updateRunner ?? createUpdateEntryRunner();
+
+        this.loadStyles(shadow);
+
+        this.root = document.createElement('div');
+        shadow.appendChild(this.root);
+
+        this.formView = new EntryFormView({
+            containerClass: 'dl-entry-edit',
+            labels: {
+                heading: 'Edit entry',
+                submit: 'Save',
+                cancel: 'Cancel',
+                dateHelp: 'Logical entry date, not timestamps.',
+                submittingText: 'Saving changes…'
+            }
+        });
+    }
+
+    public static get observedAttributes(): string[] {
+        return [];
+    }
+
+    public connectedCallback(): void {
+        this.renderLoading();
+        this.load();
+    }
+
+    private async load(): Promise<void> {
+        try {
+            const entryId = this.getEntryId();
+
+            if (!entryId) {
+                const message = 'Entry id is missing.';
+                this.renderError(message, this.emptyParams());
+                this.bindEvents();
+
+                return;
+            }
+
+            const response = await this.getRunner.run(entryId);
+
+            if (response.success) {
+                const data = response.data;
+
+                if (!data) {
+                    const message = 'Failed to load entry. Please try again.';
+                    this.renderError(message, this.emptyParams());
+                    this.bindEvents();
+
+                    return;
+                }
+
+                const params = this.mapEntryToParams(data);
+
+                this.renderForm(params);
+                this.bindEvents();
+
+                return;
+            }
+
+            const message = this.pickGetErrorMessage(response);
+
+            this.renderError(message, this.emptyParams());
+            this.bindEvents();
+        } catch (error) {
+            const message = 'Failed to load entry. Please try again.';
+
+            this.renderError(message, this.emptyParams());
+            this.bindEvents();
+        }
+    }
+
+    private bindEvents(): void {
+        this.formView.bind(this.root, {
+            onSubmit: (params: EntryFormParams) => {
+                if (this.isSubmitting) {
+                    return;
+                }
+
+                this.submit(params);
+            },
+            onCancel: () => {
+                this.onCancel();
+            }
+        });
+    }
+
+    private async submit(params: EntryFormParams): Promise<void> {
+        this.isSubmitting = true;
+
+        const entryId = this.getEntryId();
+
+        const updateParams: UpdateParams = {
+            id: entryId,
+            title: params.title,
+            body: params.body,
+            date: params.date
+        };
+
+        this.renderSubmitting(params);
+        this.bindEvents();
+
+        try {
+            const response = await this.updateRunner.run(updateParams);
+
+            if (response.success) {
+                const data = response.data;
+
+                if (!data) {
+                    const message = 'Failed to update entry. Please try again.';
+                    this.isSubmitting = false;
+
+                    this.renderError(message, params);
+                    this.bindEvents();
+
+                    return;
+                }
+
+                this.isSubmitting = false;
+
+                const updatedId = this.pickUpdatedId(entryId, data);
+
+                this.renderSuccess();
+                this.afterSuccess(updatedId);
+
+                return;
+            }
+
+            const message = this.pickUpdateErrorMessage(response);
+
+            this.isSubmitting = false;
+
+            this.renderError(message, params);
+            this.bindEvents();
+        } catch (error) {
+            const message = 'Failed to update entry. Please try again.';
+
+            this.isSubmitting = false;
+
+            this.renderError(message, params);
+            this.bindEvents();
+        }
+    }
+
+    private pickUpdatedId(entryId: string, data: unknown): string {
+        const candidate = data as {id?: string} | null;
+
+        const id = candidate?.id;
+
+        if (id && typeof id === 'string') {
+            const trimmed = id.trim();
+            return trimmed;
+        }
+
+        return entryId;
+    }
+
+    private pickGetErrorMessage(response: UseCaseResponse<GetEntryResponse>): string {
+        const errors = response.errors;
+
+        if (errors && errors.length) {
+            const message = errors.join(', ');
+            return message;
+        }
+
+        const fallback = 'Failed to load entry. Please try again.';
+        return fallback;
+    }
+
+    private pickUpdateErrorMessage(response: UseCaseResponse<Entry>): string {
+        const errors = response.errors;
+
+        if (errors && errors.length) {
+            const message = errors.join(', ');
+            return message;
+        }
+
+        const fallback = 'Failed to update entry. Please try again.';
+        return fallback;
+    }
+
+    private mapEntryToParams(entry: GetEntryResponse): EntryFormParams {
+        const params: EntryFormParams = {
+            title: entry.title ?? '',
+            body: entry.body ?? '',
+            date: entry.date ?? ''
+        };
+
+        return params;
+    }
+
+    private renderLoading(): void {
+        const html = `
+            <div class="dl-entry-edit container" data-testid="loading">
+                <div class="box">
+                    <progress class="progress is-small is-primary" max="100">Loading</progress>
+                    <p class="has-text-grey">Loading entry&hellip;</p>
+                </div>
+            </div>
+        `;
+
+        this.root.innerHTML = html;
+    }
+
+    private renderForm(params?: EntryFormParams): void {
+        this.formView.renderIdle(this.root, params);
+    }
+
+    private renderSubmitting(params: EntryFormParams): void {
+        this.formView.renderSubmitting(this.root, params);
+    }
+
+    private renderError(message: string, params: EntryFormParams): void {
+        this.formView.renderError(this.root, message, params);
+    }
+
+    private renderSuccess(): void {
+        const html = `
+            <div class="dl-entry-edit container" data-testid="success">
+                <article class="message is-success is-light">
+                    <div class="message-body">
+                        Entry updated successfully.
+                    </div>
+                </article>
+
+                <div class="mt-4">
+                    <a class="button is-light" href="/entries">Back to list</a>
+                </div>
+            </div>
+        `;
+
+        this.root.innerHTML = html;
+    }
+
+    private afterSuccess(entryId: string): void {
+        const event = new CustomEvent('dl-entry-updated', {
+            detail: {id: entryId},
+            bubbles: true,
+            composed: true
+        });
+
+        this.dispatchEvent(event);
+    }
+
+    private onCancel(): void {
+        window.location.href = '/entries';
+    }
+
+    private getEntryId(): string {
+        const attribute = EditEntryElement.entryIdAttribute;
+
+        const raw = this.getAttribute(attribute);
+
+        if (!raw) {
+            const empty = '';
+            return empty;
+        }
+
+        const trimmed = raw.trim();
+
+        return trimmed;
+    }
+
+    private emptyParams(): EntryFormParams {
+        const params: EntryFormParams = {title: '', body: '', date: ''};
+
+        return params;
+    }
+
+    private loadStyles(shadow: ShadowRoot): void {
+        const href = '/assets/css/dl-components.css';
+
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+
+        shadow.appendChild(link);
+    }
+}

--- a/frontend/src/Presentation/entries/vanilla/edit/UpdateEntryRunner.ts
+++ b/frontend/src/Presentation/entries/vanilla/edit/UpdateEntryRunner.ts
@@ -1,0 +1,34 @@
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {Entry} from '@src/Domain/Models/Entries/Entry';
+import {UseCaseRunner} from '@src/Presentation/runner/UseCaseRunner';
+import {makeUpdateEntryUseCase} from '@src/Configuration/Providers/Entries/UpdateEntryProvider';
+
+export interface UpdateEntryRunner {
+    // eslint-disable-next-line no-unused-vars
+    run: (params: {
+        id: string;
+        title: string;
+        body: string;
+        date: string;
+    }) => Promise<UseCaseResponse<Entry>>;
+}
+
+export function createUpdateEntryRunner(): UpdateEntryRunner {
+    const useCase = makeUpdateEntryUseCase();
+
+    const runner: UpdateEntryRunner = {
+        run: async (params: {
+            id: string;
+            title: string;
+            body: string;
+            date: string;
+        }): Promise<UseCaseResponse<Entry>> => {
+            const runnerResult = await UseCaseRunner.run(useCase, params);
+            const response = runnerResult as UseCaseResponse<Entry>;
+
+            return response;
+        }
+    };
+
+    return runner;
+}

--- a/frontend/src/Presentation/entries/vanilla/edit/edit.vanilla.entry.ts
+++ b/frontend/src/Presentation/entries/vanilla/edit/edit.vanilla.entry.ts
@@ -1,0 +1,34 @@
+/**
+ * Entry file for vanilla implementation of UC-5 (EditEntry).
+ *
+ * Purpose:
+ * - Register <dl-entry-edit> custom element in the global registry.
+ * - Keep tag name stable so different JS bundles (vanilla/lit/etc.)
+ *   can swap implementations without changing HTML.
+ */
+
+import {EditEntryElement} from '@src/Presentation/entries/vanilla/edit/EditEntryElement';
+
+/**
+ * Stable custom element tag name for UC-5 EditEntry.
+ */
+const tagName = 'dl-entry-edit';
+
+/**
+ * Register EditEntryElement under the stable tag name if not
+ * registered yet. This makes the entry file idempotent and safe
+ * to import from multiple places.
+ *
+ * @returns {void}
+ */
+function registerEditEntryElement(): void {
+    const existing = customElements.get(tagName);
+
+    if (!existing) {
+        const ctor = EditEntryElement;
+
+        customElements.define(tagName, ctor);
+    }
+}
+
+registerEditEntryElement();

--- a/frontend/src/Presentation/entries/vanilla/form/EntryFormView.ts
+++ b/frontend/src/Presentation/entries/vanilla/form/EntryFormView.ts
@@ -1,0 +1,377 @@
+/**
+ * EntryFormView is a reusable UI-only helper for entry create/edit forms.
+ *
+ * Purpose:
+ * - Provide a single source of truth for entry form markup (title/date/body + buttons).
+ * - Provide rendering helpers for common UI states: idle, submitting, error.
+ * - Provide form value reading and safe HTML escaping.
+ *
+ * Mechanics:
+ * - This is NOT a custom element. It is a pure view helper.
+ * - The caller owns orchestration (use-case execution, state transitions, navigation).
+ * - Every render replaces the container innerHTML; event handlers must be re-bound after render.
+ *
+ * Notes:
+ * - The view supports a configurable container class and labels to avoid hardcoding
+ *   Add/Edit-specific copy in the shared layer.
+ */
+
+export type EntryFormParams = {
+    title: string;
+    body: string;
+    date: string;
+};
+
+export type EntryFormLabels = {
+    heading: string;
+    submit: string;
+    cancel: string;
+    dateHelp: string;
+    submittingText: string;
+};
+
+export type EntryFormCallbacks = {
+    onSubmit: (params: EntryFormParams) => void;
+    onCancel: () => void;
+};
+
+export type EntryFormOptions = {
+    containerClass: string;
+    labels: EntryFormLabels;
+};
+
+export class EntryFormView {
+    private readonly options: EntryFormOptions;
+
+    public constructor(options?: Partial<EntryFormOptions>) {
+        const defaults = this.defaultOptions();
+
+        const containerClass = options?.containerClass ?? defaults.containerClass;
+
+        const labels: EntryFormLabels = {
+            heading: options?.labels?.heading ?? defaults.labels.heading,
+            submit: options?.labels?.submit ?? defaults.labels.submit,
+            cancel: options?.labels?.cancel ?? defaults.labels.cancel,
+            dateHelp: options?.labels?.dateHelp ?? defaults.labels.dateHelp,
+            submittingText: options?.labels?.submittingText ?? defaults.labels.submittingText
+        };
+
+        this.options = {containerClass, labels};
+    }
+
+    /**
+     * Render the idle state: editable form.
+     *
+     * @param {HTMLElement} root Root container whose innerHTML is replaced.
+     * @param {EntryFormParams=} params Optional initial values to prefill inputs.
+     *
+     * @returns {void}
+     */
+    public renderIdle(root: HTMLElement, params?: EntryFormParams): void {
+        const values = params ?? this.emptyParams();
+
+        const html = this.renderCardFormHtml('idle', values, {
+            disabled: false,
+            showProgress: false
+        });
+
+        root.innerHTML = html;
+    }
+
+    /**
+     * Render the submitting state: disabled form + progress.
+     *
+     * @param {HTMLElement} root Root container whose innerHTML is replaced.
+     * @param {EntryFormParams} params Current values to keep visible while submitting.
+     *
+     * @returns {void}
+     */
+    public renderSubmitting(root: HTMLElement, params: EntryFormParams): void {
+        const html = this.renderCardFormHtml('submitting', params, {
+            disabled: true,
+            showProgress: true
+        });
+
+        root.innerHTML = html;
+    }
+
+    /**
+     * Render the error state: Bulma message + editable form with previous values.
+     *
+     * @param {HTMLElement} root Root container whose innerHTML is replaced.
+     * @param {string} message Human-readable error message.
+     * @param {EntryFormParams} params Previous values to keep in the form.
+     *
+     * @returns {void}
+     */
+    public renderError(root: HTMLElement, message: string, params: EntryFormParams): void {
+        const containerClass = this.options.containerClass;
+
+        const html = `
+            <div class="${containerClass} container" data-testid="error">
+                <article class="message is-danger is-light">
+                    <div class="message-body">
+                        ${this.escapeHtml(message)}
+                    </div>
+                </article>
+
+                <div class="mt-4">
+                    ${this.renderCardFormHtml('idle', params, {
+                        disabled: false,
+                        showProgress: false,
+                        nested: true
+                    })}
+                </div>
+            </div>
+        `;
+
+        root.innerHTML = html;
+    }
+
+    /**
+     * Bind form events to the currently rendered DOM.
+     *
+     * Contract:
+     * - The caller must call bind() after each render, because render() replaces innerHTML.
+     *
+     * @param {HTMLElement} root Root container used for querySelector lookups.
+     * @param {EntryFormCallbacks} callbacks Submit and cancel callbacks.
+     *
+     * @returns {void}
+     */
+    public bind(root: HTMLElement, callbacks: EntryFormCallbacks): void {
+        const form = root.querySelector('form[data-testid="form"]');
+
+        if (form) {
+            form.addEventListener('submit', (event: Event) => {
+                event.preventDefault();
+
+                const params = this.readParams(root);
+                callbacks.onSubmit(params);
+            });
+        }
+
+        const cancel = root.querySelector('button[data-testid="cancel"]');
+
+        if (cancel) {
+            cancel.addEventListener('click', () => {
+                callbacks.onCancel();
+            });
+        }
+    }
+
+    /**
+     * Read current form values from inputs/textarea.
+     *
+     * @param {HTMLElement} root Root container used for querySelector lookups.
+     *
+     * @returns {EntryFormParams} Trimmed form values. Missing inputs yield empty strings.
+     */
+    public readParams(root: HTMLElement): EntryFormParams {
+        const title = this.readInputValue(root, 'title');
+        const body = this.readInputValue(root, 'body');
+        const date = this.readInputValue(root, 'date');
+
+        const params: EntryFormParams = {title, body, date};
+
+        return params;
+    }
+
+    private readInputValue(root: HTMLElement, name: 'title' | 'body' | 'date'): string {
+        const selector = `[name="${name}"]`;
+        const node = root.querySelector(selector);
+
+        if (!node) {
+            const empty = '';
+            return empty;
+        }
+
+        if (node instanceof HTMLInputElement) {
+            const value = node.value.trim();
+            return value;
+        }
+
+        if (node instanceof HTMLTextAreaElement) {
+            const value = node.value.trim();
+            return value;
+        }
+
+        const empty = '';
+        return empty;
+    }
+
+    private renderCardFormHtml(
+        stateTestId: 'idle' | 'submitting',
+        params: EntryFormParams,
+        options: {
+            disabled: boolean;
+            showProgress: boolean;
+            nested?: boolean;
+        }
+    ): string {
+        const containerClass = this.options.containerClass;
+
+        const wrapperStart = options.nested
+            ? ''
+            : `<div class="${containerClass} container" data-testid="${stateTestId}">`;
+
+        const wrapperEnd = options.nested ? '' : '</div>';
+
+        const titleValue = params.title ?? '';
+        const bodyValue = params.body ?? '';
+        const dateValue = params.date ?? '';
+
+        const heading = this.options.labels.heading;
+        const submitText = this.options.labels.submit;
+        const cancelText = this.options.labels.cancel;
+        const dateHelp = this.options.labels.dateHelp;
+        const submittingText = this.options.labels.submittingText;
+
+        const disabledAttr = options.disabled ? 'disabled' : '';
+        const requiredAttr = options.disabled ? '' : 'required';
+
+        const progressHtml = options.showProgress
+            ? `
+                <progress class="progress is-small is-primary" max="100">Loading</progress>
+                <p class="has-text-grey">${this.escapeHtml(submittingText)}</p>
+
+                <hr />
+            `
+            : '';
+
+        const dateInputType = options.disabled ? 'text' : 'date';
+        const datePlaceholder = options.disabled ? '' : 'placeholder="YYYY-MM-DD"';
+        const dateAutocomplete = options.disabled ? '' : 'autocomplete="off"';
+
+        const html = `
+            ${wrapperStart}
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">
+                            ${this.escapeHtml(heading)}
+                        </p>
+                    </header>
+
+                    <div class="card-content">
+                        <div class="content">
+                            ${progressHtml}
+
+                            <form data-testid="form">
+                                <div class="field">
+                                    <label class="label">Title</label>
+                                    <div class="control">
+                                        <input
+                                            class="input"
+                                            type="text"
+                                            name="title"
+                                            value="${this.escapeAttr(titleValue)}"
+                                            ${dateAutocomplete}
+                                            ${requiredAttr}
+                                            ${disabledAttr}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div class="field">
+                                    <label class="label">Date</label>
+                                    <div class="control">
+                                        <input
+                                            class="input"
+                                            type="${dateInputType}"
+                                            name="date"
+                                            value="${this.escapeAttr(dateValue)}"
+                                            ${datePlaceholder}
+                                            ${dateAutocomplete}
+                                            ${requiredAttr}
+                                            ${disabledAttr}
+                                        />
+                                    </div>
+                                    <p class="help">${this.escapeHtml(dateHelp)}</p>
+                                </div>
+
+                                <div class="field">
+                                    <label class="label">Body</label>
+                                    <div class="control">
+                                        <textarea
+                                            class="textarea"
+                                            name="body"
+                                            rows="8"
+                                            ${requiredAttr}
+                                            ${disabledAttr}
+                                        >${this.escapeHtml(bodyValue)}</textarea>
+                                    </div>
+                                </div>
+
+                                <div class="field">
+                                    <div class="control">
+                                        <div class="buttons">
+                                            <button
+                                                class="button is-primary"
+                                                type="${options.disabled ? 'button' : 'submit'}"
+                                                ${options.disabled ? 'disabled' : ''}
+                                            >
+                                                ${this.escapeHtml(submitText)}
+                                            </button>
+
+                                            <button
+                                                class="button"
+                                                type="button"
+                                                data-testid="cancel"
+                                                ${options.disabled ? 'disabled' : ''}
+                                            >
+                                                ${this.escapeHtml(cancelText)}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            ${wrapperEnd}
+        `;
+
+        return html;
+    }
+
+    private emptyParams(): EntryFormParams {
+        const params: EntryFormParams = {title: '', body: '', date: ''};
+
+        return params;
+    }
+
+    private defaultOptions(): EntryFormOptions {
+        const labels: EntryFormLabels = {
+            heading: 'Entry',
+            submit: 'Save',
+            cancel: 'Cancel',
+            dateHelp: 'Logical entry date, not timestamps.',
+            submittingText: 'Saving entry…'
+        };
+
+        const options: EntryFormOptions = {
+            containerClass: 'dl-entry-form',
+            labels
+        };
+
+        return options;
+    }
+
+    private escapeHtml(value: string): string {
+        const text = value ?? '';
+
+        const escaped = text
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#039;');
+
+        return escaped;
+    }
+
+    private escapeAttr(value: string): string {
+        const escaped = this.escapeHtml(value);
+        return escaped;
+    }
+}

--- a/frontend/src/Presentation/entries/vanilla/list/ListEntriesElement.ts
+++ b/frontend/src/Presentation/entries/vanilla/list/ListEntriesElement.ts
@@ -84,11 +84,6 @@ export class ListEntriesElement extends HTMLElement {
     }
 
     private normalizeError(error: unknown): string {
-        if (error instanceof Error) {
-            const message = error.message;
-            return message;
-        }
-
         const message = 'Failed to load entries. Please try again.';
         return message;
     }
@@ -120,15 +115,30 @@ export class ListEntriesElement extends HTMLElement {
     }
 
     private renderError(message: string): void {
+        const safeMessage = this.escapeHtml(message);
+
         const html = `
             <div class="dl-list-entries container" data-testid="error">
                 <div class="notification is-danger is-light">
-                    ${message}
+                    ${safeMessage}
                 </div>
             </div>
         `;
 
         this.root.innerHTML = html;
+    }
+
+    private escapeHtml(value: string): string {
+        const text = value ?? '';
+
+        const escaped = text
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#039;');
+
+        return escaped;
     }
 
     private renderData(page: ListEntriesData): void {

--- a/frontend/tests/Unit/Presentation/entries/vanilla/EditEntryElement.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/EditEntryElement.test.ts
@@ -1,0 +1,441 @@
+/**
+ * @file EditEntryElement.test.ts
+ *
+ * This test suite describes the behavior of the vanilla Web Component
+ * <dl-entry-edit> for UC-5 (EditEntry), using UC-3 (GetEntry) for form prefill.
+ *
+ * Scenarios:
+ * - shows loading state right after being connected to the DOM;
+ * - renders prefilled form when UC-3 returns entry successfully;
+ * - renders error state when UC-3 returns a failed response;
+ * - renders generic error message when UC-3 runner throws;
+ * - submits updated form values via UC-5 and emits dl-entry-updated on success;
+ * - renders error state when UC-5 returns a failed response.
+ */
+
+import {describe, it, expect, vi, beforeAll, beforeEach} from 'vitest';
+import {EditEntryElement} from '@src/Presentation/entries/vanilla/edit/EditEntryElement';
+import type {UseCaseResponse} from '@src/Application/DTO/Common/UseCaseResponse';
+import type {GetEntryResponse} from '@src/Application/DTO/Entries/GetEntry/GetEntryResponse';
+import type {Entry} from '@src/Domain/Models/Entries/Entry';
+import type {EntryRunner} from '@src/Presentation/entries/vanilla/view/EntryRunner';
+import type {UpdateEntryRunner} from '@src/Presentation/entries/vanilla/edit/UpdateEntryRunner';
+
+type UpdateParams = {
+    id: string;
+    title: string;
+    body: string;
+    date: string;
+};
+
+/**
+ * Ensures that EditEntryElement constructor is registered
+ * in the CustomElementRegistry before we instantiate it directly.
+ *
+ * jsdom requires the constructor to be part of the registry;
+ * otherwise "Invalid constructor" is thrown.
+ *
+ * @returns {void}
+ */
+function ensureCustomElementRegistered(): void {
+    const tagName = 'dl-entry-edit';
+    const existing = customElements.get(tagName);
+
+    if (!existing) {
+        const ctor = EditEntryElement;
+        customElements.define(tagName, ctor);
+    }
+}
+
+/**
+ * Creates a successful use-case response with provided data.
+ *
+ * @template T
+ * @param {T} data Response payload.
+ *
+ * @returns {UseCaseResponse<T>} Success response with data.
+ */
+function createSuccessResponse<T>(data: T): UseCaseResponse<T> {
+    const response: UseCaseResponse<T> = {
+        success: true,
+        code: null,
+        status: 200,
+        data,
+        errors: null
+    };
+
+    return response;
+}
+
+/**
+ * Creates a failed use-case response with provided errors.
+ *
+ * @template T
+ * @param {string} code Machine-readable error code.
+ * @param {string[]} errors Human-readable errors.
+ *
+ * @returns {UseCaseResponse<T>} Failed response without data.
+ */
+function createErrorResponse<T>(code: string, errors: string[]): UseCaseResponse<T> {
+    const response: UseCaseResponse<T> = {
+        success: false,
+        code,
+        status: 500,
+        data: null,
+        errors
+    };
+
+    return response;
+}
+
+/**
+ * Flushes pending microtasks created by async callbacks inside components.
+ *
+ * @returns {Promise<void>} Promise resolved after several microtask ticks.
+ */
+async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+/**
+ * Creates a fake GetEntry runner that always resolves with the provided response.
+ *
+ * @param {UseCaseResponse<GetEntryResponse>} response Predefined response.
+ *
+ * @returns {EntryRunner} Runner whose run() resolves with the response.
+ */
+function createFakeGetRunner(
+    response: UseCaseResponse<GetEntryResponse>
+): EntryRunner {
+    const spy = vi.fn<[string], Promise<UseCaseResponse<GetEntryResponse>>>();
+    spy.mockResolvedValue(response);
+
+    const runner: EntryRunner = {
+        run: spy
+    };
+
+    return runner;
+}
+
+/**
+ * Creates a fake UpdateEntry runner that always resolves with the provided response.
+ *
+ * @param {UseCaseResponse<Entry>} response Predefined response.
+ *
+ * @returns {UpdateEntryRunner} Runner whose run() resolves with the response.
+ */
+function createFakeUpdateRunner(
+    response: UseCaseResponse<Entry>
+): UpdateEntryRunner {
+    const spy = vi.fn<[UpdateParams], Promise<UseCaseResponse<Entry>>>();
+    spy.mockResolvedValue(response);
+
+    const runner: UpdateEntryRunner = {
+        run: spy
+    };
+
+    return runner;
+}
+
+/**
+ * Sets entry-id attribute on the element.
+ *
+ * @param {EditEntryElement} element Custom element instance.
+ * @param {string} id Entry identifier.
+ *
+ * @returns {void}
+ */
+function setEntryId(element: EditEntryElement, id: string): void {
+    element.setAttribute('entry-id', id);
+}
+
+/**
+ * Reads form nodes from the component shadow root.
+ *
+ * @param {ShadowRoot} shadow Component shadow root.
+ *
+ * @returns {{form: HTMLFormElement; title: HTMLInputElement; date: HTMLInputElement; body: HTMLTextAreaElement}}
+ */
+function getFormNodes(shadow: ShadowRoot): {
+    form: HTMLFormElement;
+    title: HTMLInputElement;
+    date: HTMLInputElement;
+    body: HTMLTextAreaElement;
+} {
+    const formNode = shadow.querySelector('form[data-testid="form"]');
+    const titleNode = shadow.querySelector('input[name="title"]');
+    const dateNode = shadow.querySelector('input[name="date"]');
+    const bodyNode = shadow.querySelector('textarea[name="body"]');
+
+    if (!(formNode instanceof HTMLFormElement)) {
+        throw new Error('Form node is missing.');
+    }
+
+    if (!(titleNode instanceof HTMLInputElement)) {
+        throw new Error('Title input is missing.');
+    }
+
+    if (!(dateNode instanceof HTMLInputElement)) {
+        throw new Error('Date input is missing.');
+    }
+
+    if (!(bodyNode instanceof HTMLTextAreaElement)) {
+        throw new Error('Body textarea is missing.');
+    }
+
+    const nodes = {
+        form: formNode,
+        title: titleNode,
+        date: dateNode,
+        body: bodyNode
+    };
+
+    return nodes;
+}
+
+describe('EditEntryElement', () => {
+    beforeAll(() => {
+        ensureCustomElementRegistered();
+    });
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('shows loading state immediately after connection', () => {
+        const entry: GetEntryResponse = {
+            id: '11111111-1111-1111-1111-111111111111',
+            title: 'Prefilled title',
+            body: 'Prefilled body',
+            date: '2026-01-01'
+        };
+
+        const getResponse = createSuccessResponse(entry);
+        const getRunner = createFakeGetRunner(getResponse);
+
+        const updateResponse = createSuccessResponse(entry as unknown as Entry);
+        const updateRunner = createFakeUpdateRunner(updateResponse);
+
+        const element = new EditEntryElement(getRunner, updateRunner);
+
+        const id = '11111111-1111-1111-1111-111111111111';
+        setEntryId(element, id);
+
+        document.body.appendChild(element);
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const loading = shadow.querySelector('[data-testid="loading"]');
+
+        expect(loading).not.toBeNull();
+        expect(loading?.textContent).toContain('Loading entry');
+    });
+
+    it('renders prefilled form when UC-3 returns entry successfully', async () => {
+        const entry: GetEntryResponse = {
+            id: '11111111-1111-1111-1111-111111111111',
+            title: 'Prefilled title',
+            body: 'Prefilled body',
+            date: '2026-01-01'
+        };
+
+        const getResponse = createSuccessResponse(entry);
+        const getRunner = createFakeGetRunner(getResponse);
+
+        const updateResponse = createSuccessResponse(entry as unknown as Entry);
+        const updateRunner = createFakeUpdateRunner(updateResponse);
+
+        const element = new EditEntryElement(getRunner, updateRunner);
+
+        const id = '11111111-1111-1111-1111-111111111111';
+        setEntryId(element, id);
+
+        document.body.appendChild(element);
+
+        await flushMicrotasks();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+
+        const loading = shadow.querySelector('[data-testid="loading"]');
+        const idle = shadow.querySelector('[data-testid="idle"]');
+        const error = shadow.querySelector('[data-testid="error"]');
+
+        expect(loading).toBeNull();
+        expect(error).toBeNull();
+        expect(idle).not.toBeNull();
+
+        const nodes = getFormNodes(shadow);
+
+        expect(nodes.title.value).toBe('Prefilled title');
+        expect(nodes.date.value).toBe('2026-01-01');
+        expect(nodes.body.value).toContain('Prefilled body');
+    });
+
+    it('renders error state when UC-3 returns a failed response', async () => {
+        const errors = ['Entry not found'];
+        const getResponse = createErrorResponse<GetEntryResponse>('ENTRY_NOT_FOUND', errors);
+        const getRunner = createFakeGetRunner(getResponse);
+
+        const updateResponse = createSuccessResponse({} as unknown as Entry);
+        const updateRunner = createFakeUpdateRunner(updateResponse);
+
+        const element = new EditEntryElement(getRunner, updateRunner);
+
+        const id = '99999999-9999-9999-9999-999999999999';
+        setEntryId(element, id);
+
+        document.body.appendChild(element);
+
+        await flushMicrotasks();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+
+        const loading = shadow.querySelector('[data-testid="loading"]');
+        const error = shadow.querySelector('[data-testid="error"]');
+
+        expect(loading).toBeNull();
+        expect(error).not.toBeNull();
+        expect(error?.textContent).toContain('Entry not found');
+    });
+
+    it('renders generic error message when UC-3 runner throws', async () => {
+        const failingGetRunner: EntryRunner = {
+            run: vi.fn().mockRejectedValue(new Error('Network broken'))
+        };
+
+        const updateResponse = createSuccessResponse({} as unknown as Entry);
+        const updateRunner = createFakeUpdateRunner(updateResponse);
+
+        const element = new EditEntryElement(failingGetRunner, updateRunner);
+
+        const id = '11111111-1111-1111-1111-111111111111';
+        setEntryId(element, id);
+
+        document.body.appendChild(element);
+
+        await flushMicrotasks();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const error = shadow.querySelector('[data-testid="error"]');
+
+        expect(error).not.toBeNull();
+        expect(error?.textContent).toContain('Failed to load entry');
+    });
+
+    it('submits updated values via UC-5 and emits dl-entry-updated on success', async () => {
+        const entry: GetEntryResponse = {
+            id: '11111111-1111-1111-1111-111111111111',
+            title: 'Prefilled title',
+            body: 'Prefilled body',
+            date: '2026-01-01'
+        };
+
+        const getResponse = createSuccessResponse(entry);
+        const getRunner = createFakeGetRunner(getResponse);
+
+        const updatedEntry: Entry = {
+            id: '11111111-1111-1111-1111-111111111111',
+            title: 'Updated title',
+            body: 'Updated body',
+            date: '2026-01-02',
+            createdAt: '2026-01-01T10:00:00Z',
+            updatedAt: '2026-01-02T10:00:00Z'
+        };
+
+        const updateResponse = createSuccessResponse(updatedEntry);
+        const updateRunner = createFakeUpdateRunner(updateResponse);
+
+        const element = new EditEntryElement(getRunner, updateRunner);
+
+        const id = '11111111-1111-1111-1111-111111111111';
+        setEntryId(element, id);
+
+        const eventSpy = vi.fn<[CustomEvent], void>();
+
+        element.addEventListener('dl-entry-updated', (event: Event) => {
+            const custom = event as CustomEvent;
+            eventSpy(custom);
+        });
+
+        document.body.appendChild(element);
+
+        await flushMicrotasks();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const nodes = getFormNodes(shadow);
+
+        nodes.title.value = 'Updated title';
+        nodes.date.value = '2026-01-02';
+        nodes.body.value = 'Updated body';
+
+        nodes.form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+
+        const submitting = shadow.querySelector('[data-testid="submitting"]');
+
+        expect(submitting).not.toBeNull();
+
+        await flushMicrotasks();
+
+        const success = shadow.querySelector('[data-testid="success"]');
+
+        expect(success).not.toBeNull();
+
+        expect(eventSpy).toHaveBeenCalledTimes(1);
+
+        const eventArg = eventSpy.mock.calls[0][0];
+        expect(eventArg.detail).toEqual({id});
+
+        const updateFn = updateRunner.run as unknown as ReturnType<typeof vi.fn>;
+        expect(updateFn).toHaveBeenCalledTimes(1);
+
+        const calledParams = updateFn.mock.calls[0][0] as UpdateParams;
+
+        expect(calledParams).toEqual({
+            id,
+            title: 'Updated title',
+            body: 'Updated body',
+            date: '2026-01-02'
+        });
+    });
+
+    it('renders error state when UC-5 returns a failed response', async () => {
+        const entry: GetEntryResponse = {
+            id: '11111111-1111-1111-1111-111111111111',
+            title: 'Prefilled title',
+            body: 'Prefilled body',
+            date: '2026-01-01'
+        };
+
+        const getResponse = createSuccessResponse(entry);
+        const getRunner = createFakeGetRunner(getResponse);
+
+        const errors = ['Validation failed'];
+        const updateResponse = createErrorResponse<Entry>('UPDATE_FAILED', errors);
+        const updateRunner = createFakeUpdateRunner(updateResponse);
+
+        const element = new EditEntryElement(getRunner, updateRunner);
+
+        const id = '11111111-1111-1111-1111-111111111111';
+        setEntryId(element, id);
+
+        document.body.appendChild(element);
+
+        await flushMicrotasks();
+
+        const shadow = element.shadowRoot as ShadowRoot;
+        const nodes = getFormNodes(shadow);
+
+        nodes.title.value = 'Updated title';
+        nodes.date.value = '2026-01-02';
+        nodes.body.value = 'Updated body';
+
+        nodes.form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+
+        await flushMicrotasks();
+
+        const error = shadow.querySelector('[data-testid="error"]');
+
+        expect(error).not.toBeNull();
+        expect(error?.textContent).toContain('Validation failed');
+    });
+});

--- a/frontend/tests/Unit/Presentation/entries/vanilla/edit.vanilla.entry.test.ts
+++ b/frontend/tests/Unit/Presentation/entries/vanilla/edit.vanilla.entry.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @file edit.vanilla.entry.test.ts
+ *
+ * This test verifies that the vanilla entry file for UC-5 (EditEntry)
+ * registers the <dl-entry-edit> custom element in the CustomElementRegistry.
+ *
+ * It guarantees:
+ * - the HTML tag remains a stable contract;
+ * - the registered constructor is EditEntryElement;
+ * - switching bundles later (vanilla/lit/etc.) only changes the implementation
+ *   behind the same tag name.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {EditEntryElement} from '@src/Presentation/entries/vanilla/edit/EditEntryElement';
+
+describe('edit.vanilla.entry', () => {
+    it('registers <dl-entry-edit> with EditEntryElement constructor', async () => {
+        const tagName = 'dl-entry-edit';
+
+        // Import entry file that performs registration as a side effect.
+        await import('@src/Presentation/entries/vanilla/edit/edit.vanilla.entry');
+
+        const registeredConstructor = customElements.get(tagName);
+
+        expect(registeredConstructor).toBe(EditEntryElement);
+    });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -42,8 +42,11 @@ export default defineConfig({
                     'src/Presentation/entries/vanilla/view/view.vanilla.entry.ts'
                 ),
 
-                'entry-add-vanilla': r('src/Presentation/entries/vanilla/add/add.vanilla.entry.ts'),
+                'entry-edit-vanilla': r(
+                    'src/Presentation/entries/vanilla/edit/edit.vanilla.entry.ts'
+                ),
 
+                'entry-add-vanilla': r('src/Presentation/entries/vanilla/add/add.vanilla.entry.ts'),
                 'dl-components': r('ui/scss/dl-components.scss')
             },
             output: {


### PR DESCRIPTION
Implement entry edit page using a vanilla Web Component: reuse add-form layout, load entry data, submit updates via UC-5, and keep HTML tag stable for future bundle swaps.

Resolve #68